### PR TITLE
Fix db_type() exception in sync_translation_fields command

### DIFF
--- a/modeltranslation/management/commands/sync_translation_fields.py
+++ b/modeltranslation/management/commands/sync_translation_fields.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
         for lang in missing_langs:
             new_field = build_localized_fieldname(field_name, lang)
             f = model._meta.get_field(new_field)
-            col_type = f.db_type(connection)
+            col_type = f.db_type(connection=connection)
             field_sql = [style.SQL_FIELD(qn(f.column)),
                          style.SQL_COLTYPE(col_type)]
             # column creation


### PR DESCRIPTION
Fix for an exception:

> TypeError: db_type() got multiple values for keyword argument 'connection'

Explanation: http://stackoverflow.com/questions/7068057/explicit-argument-in-signature-does-not-work-very-odd

Found this while working on a site. I hope this helps.
