### PR TITLE
Fix download URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={'modeltranslation': ['static/modeltranslation/css/*.css',
                                        'static/modeltranslation/js/*.js']},
     requires=['django(>=1.3)'],
-    download_url='https://github.com/downloads/deschler/django-modeltranslation/django-modeltranslation-%s.tar.gz' % version,
+    download_url='https://github.com/deschler/django-modeltranslation/archive/%s.tar.gz' % version,
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.5',


### PR DESCRIPTION
https://github.com/downloads/deschler/django-modeltranslation/django-modeltranslation-0.5b1.tar.gz returns 404.
Whereas https://github.com/deschler/django-modeltranslation/archive/0.5b1.tar.gz is ok.

This pull-request fixes the download URL.

Note: the download URL seems used by either zc.recipe.egg or z3c.recipe.scripts, i.e. broken download URL means download problems with buildout.
