### PR TITLE
Fixed broken tabindex on Tabbed Translation Fields

### DIFF
--- a/docs/modeltranslation/admin.rst
+++ b/docs/modeltranslation/admin.rst
@@ -244,7 +244,26 @@ The proposed way to include it is through the inner ``Media`` class of a
                 'screen': ('modeltranslation/css/tabbed_translation_fields.css',),
             }
 
-Django´s shipped version of jquery is no longer compatible with jquery ui 1.10, so we need to include a newer one here.
+Django's shipped version of jquery is no longer compatible with jquery ui 1.10, so you need to include a newer one here.
+
+However, if you have to stick to either Django's built-in jquery, or rely on jquery ui 1.8 or below, include this in your ``Media`` class instead (but be aware, the form's tabindex on older jquery ui versions is broken):
+
+.. code-block:: python
+
+    class NewsAdmin(TranslationAdmin):
+        class Media:
+            js = (
+                'modeltranslation/js/force_jquery.js',
+                'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js',
+                'modeltranslation/js/tabbed_translation_fields.js',
+            )
+            css = {
+                'screen': ('modeltranslation/css/tabbed_translation_fields.css',),
+            }
+
+The ``force_jquery.js`` script is necessary when using Django's built-in
+``django.jQuery`` object. Otherwise the *normal* ``jQuery`` object won't be
+available to the included (non-namespaced) jquery-ui library.
 
 Standard jquery-ui theming can be used to customize the look of tabs, the
 provided css file is supposed to work well with a default Django admin.

--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -5,6 +5,12 @@
 * http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery.ui.core.css
 */
 
+/*
+backward compatibility:
+.ui-tabs-selected:      jquery ui <  1.10
+.ui-tabs-active classes jquery ui >= 1.10
+*/
+
 /* Layout helpers
 ----------------------------------*/
 .ui-helper-hidden { display: none; }
@@ -24,8 +30,8 @@
 .ui-tabs .ui-tabs-nav { margin: 0; padding: .2em .2em 0; }
 .ui-tabs .ui-tabs-nav li { list-style: none; float: left; position: relative; top: 1px; margin: 0 .2em 1px 0; border-bottom: 0 !important; padding: 0; white-space: nowrap; }
 .ui-tabs .ui-tabs-nav li a { float: left; padding: .5em 1em; text-decoration: none; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-active { margin-bottom: 0; padding-bottom: 1px; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
+.ui-tabs .ui-tabs-nav li.ui-tabs-active, .ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 1px; }
+.ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
 .ui-tabs .ui-tabs-nav li a, .ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a { cursor: pointer; } /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
 .ui-tabs .ui-tabs-panel { display: block; border-width: 0; padding: 1em 1.4em; background: none; }
 .ui-tabs .ui-tabs-hide {
@@ -54,7 +60,7 @@
     font-size: 12px;
 }
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-active a {
+.ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
     background: #7CA0C7 repeat-x;
     color: #fff;
     padding: 6px 10px 4px 10px;

--- a/modeltranslation/static/modeltranslation/js/force_jquery.js
+++ b/modeltranslation/static/modeltranslation/js/force_jquery.js
@@ -1,0 +1,3 @@
+if (!jQuery) {
+    jQuery = django.jQuery;
+}

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -356,7 +356,11 @@ var google, django, gettext;
                 var self = this;
                 this.$select.change(function () {
                     $.each(tabs, function (idx, tab) {
-                        tab.tabs('option', 'active', parseInt(self.$select.val()));
+                        try { //jquery ui => 1.10 api changed, we keep backward compatibility
+                            tab.tabs('select', parseInt(self.$select.val(), 10));
+                        } catch(e) {
+                            tab.tabs('option', 'active', parseInt(self.$select.val(), 10));
+                        }
                     });
                 });
             },
@@ -364,7 +368,11 @@ var google, django, gettext;
             activateTab: function(tabs) {
                 var self = this;
                 $.each(tabs, function (idx, tab) {
-                    tab.tabs('option', 'active', parseInt(self.$select.val()));
+                    try { //jquery ui => 1.10 api changed, we keep backward compatibility
+                        tab.tabs('select', parseInt(self.$select.val(), 10));
+                    } catch(e) {
+                        tab.tabs('option', 'active', parseInt(self.$select.val(), 10));
+                    }
                 });
             }
         };


### PR DESCRIPTION
Hi

I fixed the broken tabindex when using Tabbed Translation Fields in Django Admin by upgrading to the latest jquery ui. This also needs a newer jquery, so i removed the force_jquery.js and updated the docs for it.
