### PR TITLE
Testing with app settings

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -31,8 +31,8 @@ class FallbackModel2(models.Model):
 
 class FileFieldsModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
-    file = models.FileField(upload_to='test', null=True, blank=True)
-    image = models.ImageField(upload_to='test', null=True, blank=True)
+    file = models.FileField(upload_to='modeltranslation_tests', null=True, blank=True)
+    image = models.ImageField(upload_to='modeltranslation_tests', null=True, blank=True)
 
 
 ########## Custom fields testing

--- a/modeltranslation/tests/settings.py
+++ b/modeltranslation/tests/settings.py
@@ -2,11 +2,8 @@
 """
 Settings overrided for test time
 """
-import os
 from django.conf import settings
 
-
-DIRNAME = os.path.dirname(__file__)
 
 INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + (
     'modeltranslation.tests',
@@ -16,9 +13,6 @@ INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + (
     #INSTALLED_APPS += ('django.contrib.staticfiles',)
 
 #STATIC_URL = '/static/'
-
-MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(DIRNAME, 'media/')
 
 LANGUAGES = (('de', 'Deutsch'),
              ('en', 'English'))


### PR DESCRIPTION
A couple of small test fixes that were needed to test modeltranslation alongside framework / project; changes summary:
-- consistently restore active language after each test;
-- reload settings after `autodiscover` tests as they may change `FALLBACK_LANGUAGES` due to some interplay between `reload_override_settings` and the custom installed apps override (maybe someone will be able to trace this one further: fallback languages are sometimes empty on entry to the `reload_override_settings` and end up containing the default language on exit);
-- make sure timezone support is disabled for the date / time fields tests;
-- make the file field tests resistant to some other test being first to initialize the default storage with some other media root / location (and hopefully make them work with non-filesystem storages).
