### PR TITLE
Quicker load and no debug print statement

### DIFF
--- a/modeltranslation/models.py
+++ b/modeltranslation/models.py
@@ -28,6 +28,10 @@ def autodiscover():
             # this import will have to reoccur on the next request and this
             # could raise NotRegistered and AlreadyRegistered exceptions
             translator._registry = before_import_registry
+            # Re-raise ImportError in case it was raised from the
+            # 'translation' module.
+            if module_has_submodule(mod, 'translation'):
+                raise
 
     for module in TRANSLATION_FILES:
         import_module(module)

--- a/modeltranslation/models.py
+++ b/modeltranslation/models.py
@@ -7,8 +7,6 @@ def autodiscover():
     not present. This forces an import on them to register.
     Also import explicit modules.
     """
-    import os
-    import sys
     import copy
     from django.conf import settings
     from django.utils.importlib import import_module


### PR DESCRIPTION
Thanks for a very useful project!! :)

I've removed an annoying print statement in `auto_discover()` regarding registered models. I don't find it useful since it's very easy to debug whether a model is registered or not, and I think the app/developer can live without it.

The catch-reraise pattern on non-`ImportError` has also been reduced to avoid first raising an ImportError and then detecting if there is a sub-module (which there obviously isn't when it's an ImportError).
