### PR TITLE
Incompatibility with django-nested-inlines fixed

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -67,6 +67,9 @@ var google, django, gettext;
                 } else if (idBits.length === 4) {
                     // Handle standard inlines with model used by inline more than once
                     idPrefix = idBits[0] + '-' + idBits[1] + '-' + idBits[2] + '-' + idPrefix;
+                } else if (idBits.length === 5 && idBits[3] != '__prefix__') {
+                    // Handle nested inlines (https://github.com/Soaa-/django-nested-inlines)
+                    idPrefix = idBits[0] + '-' + idBits[1] + '-' + idBits[2] + '-' + idBits[3] + '-' + this.origFieldname;
                 } else if (idBits.length === 6) {
                     // Handle generic inlines
                     idPrefix = idBits[0] + '-' + idBits[1] + '-' + idBits[2] + '-' +


### PR DESCRIPTION
# Problem

When using https://github.com/Soaa-/django-nested-inlines, the tabular tabs on the second nested level are broken. The tabs are only showed for the last item and the table layout breaks.

![bildschirmfoto 2013-11-27 um 13 51 35](https://f.cloud.github.com/assets/569215/1631358/dd81e3a0-5762-11e3-8c23-e027925e9e77.png)
# Reason

This is due to TranslationField#buildGroupId dropping those fields as it doesn't understand their ids.
# Fix

Handle nested inline ids explicitely.
