### PR TITLE
Describe use-case for MODELTRANSLATION_LANGUAGES

### DIFF
--- a/docs/modeltranslation/installation.rst
+++ b/docs/modeltranslation/installation.rst
@@ -175,7 +175,9 @@ Example::
     )
     MODELTRANSLATION_LANGUAGES = ('en', 'de')
 
-.. note:: We doubt this setting will ever be needed, but why not add it since we can?
+.. note::
+    This setting may become useful if your users shall produce content for a restricted
+    set of languages, while your application is translated into a greater number of locales.
 
 
 .. _settings-modeltranslation_fallback_languages:


### PR DESCRIPTION
I've got a use-case !

Our application is translated into a number of languages, so we keep the `LANGUAGES` setting with the adequate list (_configured in package_). But the application is used to produce pages (like a CMS) into a subset of languages (_configured during deployment_)
