### PR TITLE
remove bad style

### DIFF
--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -36,7 +36,7 @@ backward compatibility:
 .ui-tabs .ui-tabs-panel { display: block; border-width: 0; padding: 1em 1.4em; background: none; }
 .ui-tabs .ui-tabs-hide {
     position: absolute;
-    left: -10000px;
+    display: none;
 }
 
 /* custom tabs theme */


### PR DESCRIPTION
In all browsers except Firefox left: -10000px; don't work, so I remove this and add display: none; that work in all browsers.
