### PR TITLE
[Django 1.7] Support AppConfig in INSTALLED_APPS

### DIFF
--- a/modeltranslation/models.py
+++ b/modeltranslation/models.py
@@ -17,10 +17,15 @@ def autodiscover():
     from modeltranslation.translator import translator
     from modeltranslation.settings import TRANSLATION_FILES, DEBUG
 
-    for app in settings.INSTALLED_APPS:
-        mod = import_module(app)
+    if django.get_version() < '1.7':
+        mods = [import_module(app) for app in settings.INSTALLED_APPS]
+    else:
+        from django import apps
+        mods = [app_config.module for app_config in apps.apps.get_app_configs()]
+
+    for mod in mods:
         # Attempt to import the app's translation module.
-        module = '%s.translation' % app
+        module = '%s.translation' % mod.__name__
         before_import_registry = copy.copy(translator._registry)
         try:
             import_module(module)


### PR DESCRIPTION
Updated autodiscover to support AppConfig instances that are defined in INSTALLED_APPS

Example:
INSTALLED_APPS = (
    ModeltranslationConfig('modeltranslation', import_module('modeltranslation'))
)
