### PR TITLE
Fix support for Indonesian language

### DIFF
--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -965,6 +965,10 @@ class ForeignKeyFieldsTest(ModeltranslationTestBase):
         self.assertEqual(manager.filter(test_fks__title='f_title_de').count(), 0)
         self.assertEqual(manager.filter(test_fks__title_de='f_title_de').count(), 1)
 
+    def test_indonesian(self):
+        field = models.ForeignKeyModel._meta.get_field('test')
+        self.assertNotEqual(field.attname, build_localized_fieldname(field.name, 'id'))
+
     def assertQuerysetsEqual(self, qs1, qs2):
         pk = lambda o: o.pk
         return self.assertEqual(sorted(qs1, key=pk), sorted(qs2, key=pk))

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -30,10 +30,16 @@ def get_translation_fields(field):
 
 
 def build_localized_fieldname(field_name, lang):
+    if lang == 'id':
+        # The 2-letter Indonesian language code is problematic with the
+        # current naming scheme as Django foreign keys also add "id" suffix.
+        lang = 'ind'
     return str('%s_%s' % (field_name, lang.replace('-', '_')))
 
 
 def _build_localized_verbose_name(verbose_name, lang):
+    if lang == 'id':
+        lang = 'ind'
     return force_text('%s [%s]') % (force_text(verbose_name), lang)
 build_localized_verbose_name = lazy(_build_localized_verbose_name, six.text_type)
 


### PR DESCRIPTION
Admittedly, the problem was identified by the new system checks framework (after removing `models = None` is `modeltranslation.tests`, more on this later), however the messages were a bit cryptic (*), so I've added a simple specific test.

Note that the Indonesian language is now in the [default `LANGUAGES`](https://github.com/django/django/blob/master/django/conf/global_settings.py#L88), so it's not so unlikely that non-Indonesians run into the problem.

(*) `ForeignKeyModel.test_id: (models.E006) The field 'test_id' clashes with the field 'test' from model 'foreignkeymodel'`
