### PR TITLE
Fixes for test_update_command

### DIFF
--- a/docs/modeltranslation/commands.rst
+++ b/docs/modeltranslation/commands.rst
@@ -8,6 +8,8 @@ Management Commands
 The ``update_translation_fields`` Command
 -----------------------------------------
 
+.. versionchanged:: 0.8
+
 In case modeltranslation was installed in an existing project and you
 have specified to translate fields of models which are already synced to the
 database, you have to update your database schema (see :ref:`db-fields`).
@@ -34,8 +36,9 @@ otherwise nothing is copied.
     the command will examine your ``settings.LANGUAGES`` variable and the first
     language declared there will be used as the default language.
 
-All translated models (as specified in the translation files) from all apps will be
-populated with initial data.
+On default, all translated models (as specified in the translation files) from
+all apps will be populated with initial data, but you can provide an ``--app``
+option to limit the population to models from a single app with a given label.
 
 
 .. _commands-sync_translation_fields:
@@ -44,6 +47,7 @@ The ``sync_translation_fields`` Command
 ---------------------------------------
 
 .. versionadded:: 0.4
+.. versionchanged:: 0.8
 
 .. code-block:: console
 
@@ -56,6 +60,8 @@ a registered model.
 
 However, if you are using South in your project, in most cases it's recommended to use migration
 instead of ``sync_translation_fields``. See :ref:`db-fields` for detailed info and use cases.
+
+You may limit detection of new fields to models from a single app using the ``--app`` option.
 
 
 The ``loaddata`` Command

--- a/modeltranslation/management/commands/sync_translation_fields.py
+++ b/modeltranslation/management/commands/sync_translation_fields.py
@@ -30,16 +30,19 @@ class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
         make_option('--noinput', action='store_false', dest='interactive', default=True,
                     help='Do NOT prompt the user for input of any kind.'),
+        make_option('--app', default=None,
+                    help='Limit looking for missing columns to a single app.'),
     )
 
     def handle_noargs(self, **options):
         self.cursor = connection.cursor()
         self.introspection = connection.introspection
         self.interactive = options['interactive']
-        self.verbosity = int(options.get('verbosity'))
+        self.verbosity = int(options['verbosity'])
+        self.app = options.get('app') or options.get('app_config')
 
         found_missing_columns = False
-        models = translator.get_registered_models(abstract=False)
+        models = translator.get_registered_models(abstract=False, app=self.app)
         for model in models:
             db_table = model._meta.db_table
             model_full_name = '%s.%s' % (model._meta.app_label, model._meta.object_name)

--- a/modeltranslation/management/commands/sync_translation_fields.py
+++ b/modeltranslation/management/commands/sync_translation_fields.py
@@ -11,6 +11,7 @@ Credits: Heavily inspired by django-transmeta's sync_transmeta_db command.
 """
 from optparse import make_option
 
+import django
 from django.core.management.base import NoArgsCommand
 from django.core.management.color import no_style
 from django.db import connection, transaction
@@ -19,27 +20,6 @@ from django.utils.six import moves
 from modeltranslation.settings import AVAILABLE_LANGUAGES
 from modeltranslation.translator import translator
 from modeltranslation.utils import build_localized_fieldname
-
-
-def ask_for_confirmation(sql_sentences, model_full_name, interactive, verbosity):
-    if interactive or verbosity > 0:
-        print('\nSQL to synchronize "%s" schema:' % model_full_name)
-        for sentence in sql_sentences:
-            print('   %s' % sentence)
-    while True:
-        prompt = '\nAre you sure that you want to execute the previous SQL: (y/n) [n]: '
-        if interactive:
-            answer = moves.input(prompt).strip()
-        else:
-            answer = 'y'
-        if answer == '':
-            return False
-        elif answer not in ('y', 'n', 'yes', 'no'):
-            print('Please answer yes or no')
-        elif answer == 'y' or answer == 'yes':
-            return True
-        else:
-            return False
 
 
 class Command(NoArgsCommand):
@@ -53,81 +33,93 @@ class Command(NoArgsCommand):
     )
 
     def handle_noargs(self, **options):
-        """
-        Command execution.
-        """
         self.cursor = connection.cursor()
         self.introspection = connection.introspection
         self.interactive = options['interactive']
         self.verbosity = int(options.get('verbosity'))
 
-        found_missing_fields = False
+        found_missing_columns = False
         models = translator.get_registered_models(abstract=False)
         for model in models:
             db_table = model._meta.db_table
-            model_full_name = '%s.%s' % (model._meta.app_label, model._meta.module_name)
+            model_full_name = '%s.%s' % (model._meta.app_label, model._meta.object_name)
+
             opts = translator.get_options_for_model(model)
-            for field_name, fields in opts.local_fields.items():
-                # Take `db_column` attribute into account
-                field = list(fields)[0]
-                column_name = field.db_column if field.db_column else field_name
-                missing_langs = list(self.get_missing_languages(column_name, db_table))
-                if missing_langs:
-                    found_missing_fields = True
+            for field_name in opts.local_fields.keys():
+                field = model._meta.get_field(field_name)
+
+                missing_columns = self.find_missing_columns(field, db_table)
+                if not missing_columns:
+                    continue
+                found_missing_columns = True
+                field_full_name = '%s.%s' % (model_full_name, field_name)
+                if self.verbosity > 0:
+                    self.stdout.write('Missing translation columns for field "%s": %s' % (
+                        field_full_name, ', '.join(missing_columns.keys())))
+
+                statements = self.generate_add_column_statements(field, missing_columns, model)
+                if self.interactive or self.verbosity > 0:
+                    self.stdout.write('\nStatements to be executed for "%s":' % field_full_name)
+                    for statement in statements:
+                        self.stdout.write('   %s' % statement)
+                if self.interactive:
+                    answer = None
+                    prompt = ('\nAre you sure that you want to execute the printed statements:'
+                              ' (y/n) [n]: ')
+                    while answer not in ('', 'y', 'n', 'yes', 'no'):
+                        answer = moves.input(prompt).strip()
+                        prompt = 'Please answer yes or no: '
+                    execute = (answer == 'y' or answer == 'yes')
+                else:
+                    execute = True
+                if execute:
                     if self.verbosity > 0:
-                        print('Missing languages in "%s" field from "%s" model: %s' % (
-                            field_name, model_full_name, ', '.join(missing_langs)))
-                    sql_sentences = self.get_sync_sql(field_name, missing_langs, model)
-                    execute_sql = ask_for_confirmation(
-                        sql_sentences, model_full_name, self.interactive, self.verbosity)
-                    if execute_sql:
-                        if self.verbosity > 0:
-                            print('Executing SQL...')
-                        for sentence in sql_sentences:
-                            self.cursor.execute(sentence)
-                        if self.verbosity > 0:
-                            print('Done')
-                    else:
-                        if self.verbosity > 0:
-                            print('SQL not executed')
+                        self.stdout.write('Executing statements...')
+                    for statement in statements:
+                        self.cursor.execute(statement)
+                    if self.verbosity > 0:
+                        self.stdout.write('Done')
+                else:
+                    if self.verbosity > 0:
+                        self.stdout.write('Statements not executed')
 
-        transaction.commit_unless_managed()
+        if django.VERSION < (1, 6) and found_missing_columns:
+            transaction.commit_unless_managed()
 
-        if self.verbosity > 0 and not found_missing_fields:
-            print('No new translatable fields detected')
+        if self.verbosity > 0 and not found_missing_columns:
+            self.stdout.write('No new translatable fields detected')
 
-    def get_table_fields(self, db_table):
+    def find_missing_columns(self, field, db_table):
         """
-        Gets table fields from schema.
+        Returns a dictionary of (code, column name) for languages for which
+        the given field doesn't have a translation column in the database.
         """
-        db_table_desc = self.introspection.get_table_description(self.cursor, db_table)
-        return [t[0] for t in db_table_desc]
-
-    def get_missing_languages(self, field_name, db_table):
-        """
-        Gets only missings fields.
-        """
-        db_table_fields = self.get_table_fields(db_table)
+        missing_columns = {}
+        db_column = field.db_column if field.db_column else field.name
+        db_table_description = self.introspection.get_table_description(self.cursor, db_table)
+        db_table_columns = [t[0] for t in db_table_description]
         for lang_code in AVAILABLE_LANGUAGES:
-            if build_localized_fieldname(field_name, lang_code) not in db_table_fields:
-                yield lang_code
+            lang_column = build_localized_fieldname(db_column, lang_code)
+            if lang_column not in db_table_columns:
+                missing_columns[lang_code] = lang_column
+        return missing_columns
 
-    def get_sync_sql(self, field_name, missing_langs, model):
+    def generate_add_column_statements(self, field, missing_columns, model):
         """
-        Returns SQL needed for sync schema for a new translatable field.
+        Returns database statements needed to add missing columns for the
+        field.
         """
-        qn = connection.ops.quote_name
+        statements = []
         style = no_style()
-        sql_output = []
+        qn = connection.ops.quote_name
         db_table = model._meta.db_table
-        for lang in missing_langs:
-            new_field = build_localized_fieldname(field_name, lang)
-            f = model._meta.get_field(new_field)
-            col_type = f.db_type(connection=connection)
-            field_sql = [style.SQL_FIELD(qn(f.column)), style.SQL_COLTYPE(col_type)]
-            # column creation
-            stmt = "ALTER TABLE %s ADD COLUMN %s" % (qn(db_table), ' '.join(field_sql))
-            if not f.null:
-                stmt += " " + style.SQL_KEYWORD('NOT NULL')
-            sql_output.append(stmt + ";")
-        return sql_output
+        db_column_type = field.db_type(connection=connection)
+        for lang_column in missing_columns.values():
+            statement = 'ALTER TABLE %s ADD COLUMN %s %s' % (qn(db_table),
+                                                             style.SQL_FIELD(qn(lang_column)),
+                                                             style.SQL_COLTYPE(db_column_type))
+            if not model._meta.get_field(lang_column).null:
+                # Just "not field.null" if we change the nullability politics.
+                statement += ' ' + style.SQL_KEYWORD('NOT NULL')
+            statements.append(statement + ';')
+        return statements

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from optparse import make_option
+
 from django.db.models import F, Q
 from django.core.management.base import NoArgsCommand
 
@@ -11,13 +13,20 @@ class Command(NoArgsCommand):
     help = ('Updates empty values of default translation fields using'
             ' values from original fields (in all translated models).')
 
+    option_list = NoArgsCommand.option_list + (
+        make_option('--app', default=None,
+                    help='Limit updating values to a single app.'),
+    )
+
     def handle_noargs(self, **options):
-        verbosity = int(options['verbosity'])
-        if verbosity > 0:
+        self.verbosity = int(options['verbosity'])
+        self.app = options.get('app') or options.get('app_config')
+
+        if self.verbosity > 0:
             self.stdout.write("Using default language: %s\n" % DEFAULT_LANGUAGE)
-        models = translator.get_registered_models(abstract=False)
+        models = translator.get_registered_models(abstract=False, app=self.app)
         for model in models:
-            if verbosity > 0:
+            if self.verbosity > 0:
                 self.stdout.write("Updating data of model '%s'\n" % model)
             opts = translator.get_options_for_model(model)
             for field_name in opts.fields.keys():

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -4,7 +4,6 @@ from optparse import make_option
 from django.db.models import F, Q
 from django.core.management.base import NoArgsCommand
 
-from modeltranslation.settings import DEFAULT_LANGUAGE
 from modeltranslation.translator import translator
 from modeltranslation.utils import build_localized_fieldname
 
@@ -22,15 +21,13 @@ class Command(NoArgsCommand):
         self.verbosity = int(options['verbosity'])
         self.app = options.get('app') or options.get('app_config')
 
-        if self.verbosity > 0:
-            self.stdout.write("Using default language: %s\n" % DEFAULT_LANGUAGE)
         models = translator.get_registered_models(abstract=False, app=self.app)
         for model in models:
             if self.verbosity > 0:
                 self.stdout.write("Updating data of model '%s'\n" % model)
             opts = translator.get_options_for_model(model)
             for field_name in opts.fields.keys():
-                def_lang_fieldname = build_localized_fieldname(field_name, DEFAULT_LANGUAGE)
+                def_lang_fieldname = build_localized_fieldname(field_name, opts.default_language)
 
                 # We'll only update fields which do not have an existing value
                 q = Q(**{def_lang_fieldname: None})

--- a/modeltranslation/tests/managed_app/models.py
+++ b/modeltranslation/tests/managed_app/models.py
@@ -1,0 +1,16 @@
+from django.db import models
+
+
+class News(models.Model):
+    title = models.CharField(max_length=50)
+    visits = models.SmallIntegerField(blank=True, null=True)
+
+    class Meta:
+        app_label = 'managed_app'
+
+
+class Other(models.Model):
+    name = models.CharField(max_length=50)
+
+    class Meta:
+        app_label = 'managed_app'

--- a/modeltranslation/tests/managed_app/translation.py
+++ b/modeltranslation/tests/managed_app/translation.py
@@ -1,0 +1,10 @@
+from modeltranslation.translator import translator, TranslationOptions
+
+from .models import News
+
+
+class NewsTranslationOptions(TranslationOptions):
+    fields = ('title',)
+
+
+translator.register(News, NewsTranslationOptions)

--- a/modeltranslation/tests/settings.py
+++ b/modeltranslation/tests/settings.py
@@ -5,9 +5,12 @@ Settings overrided for test time
 from django.conf import settings
 
 
-INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + (
+TEST_APPS = (
     'modeltranslation.tests',
+    'modeltranslation.tests.managed_app',
 )
+
+INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + TEST_APPS
 
 LANGUAGES = (('de', 'Deutsch'),
              ('en', 'English'))

--- a/modeltranslation/tests/test_settings.py
+++ b/modeltranslation/tests/test_settings.py
@@ -1,6 +1,0 @@
-"""
-Get test settings in dict format (for use with settings_override).
-"""
-from . import settings as _settings
-
-TEST_SETTINGS = dict((k, getattr(_settings, k)) for k in dir(_settings) if k == k.upper())

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2004,7 +2004,7 @@ class ManagementCommandsTests(DirtyRegistryTestBase):
         self.assertEqual('already', obj2['title_de'])
         self.assertEqual('initial', obj2['title'])
 
-        call_command('update_translation_fields', verbosity=0)
+        call_command('update_translation_fields', verbosity=0, app='tests')
 
         obj1 = models.TestModel.objects.get(pk=pk1)
         obj2 = models.TestModel.objects.get(pk=pk2)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -31,7 +31,6 @@ except ImportError:
 
 from modeltranslation import admin, settings as mt_settings, translator
 from modeltranslation.forms import TranslationModelForm
-from modeltranslation.management.commands import sync_translation_fields
 from modeltranslation.manager import (MultilingualManager, MultilingualQuerySet,
                                       append_lookup_keys, append_lookup_key)
 from modeltranslation.models import autodiscover, handle_translation_registrations
@@ -1922,7 +1921,6 @@ class ManagementCommandsTests(DirtyRegistryTestBase):
 
         # Adding a new language and syncing should create a new column.
         with reload_override_settings(LANGUAGES=(('de', 'Deutsch'), ('ht', 'Kreyòl ayisyen'),)):
-            imp.reload(sync_translation_fields)
             self.reregister_app('modeltranslation.tests.managed_app')
             if django.VERSION < (1, 8):
                 call_command('sync_translation_fields', app='managed_app',
@@ -1934,7 +1932,6 @@ class ManagementCommandsTests(DirtyRegistryTestBase):
 
         # An app config or models module can also be used in place of a label.
         with reload_override_settings(LANGUAGES=(('de', 'Deutsch'), ('fo', 'føroyskt'),)):
-            imp.reload(sync_translation_fields)
             self.reregister_app('modeltranslation.tests.managed_app')
             if django.VERSION < (1, 7):
                 app_models = app_cache.get_app('managed_app')

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -36,7 +36,7 @@ from modeltranslation.forms import TranslationModelForm
 from modeltranslation.manager import (MultilingualManager, MultilingualQuerySet,
                                       append_lookup_keys, append_lookup_key)
 from modeltranslation.models import autodiscover, handle_translation_registrations
-from modeltranslation.tests.test_settings import TEST_SETTINGS
+from modeltranslation.tests import settings as test_settings
 from modeltranslation.translator import (DescendantRegistered, NotRegistered, TranslationOptions,
                                          translator)
 from modeltranslation.utils import (auto_populate, build_css_class, build_localized_fieldname,
@@ -53,6 +53,11 @@ request = None
 
 # How many models are registered for tests.
 TEST_MODELS = 29
+
+# Settings for modeltranslation tests. An additional TEST_APPS setting
+# specifies a list of apps that will be dynamically loaded and have their
+# models registered under the new settings (notably with LANGUAGES given).
+TEST_SETTINGS = dict((k, getattr(test_settings, k)) for k in dir(test_settings) if k == k.upper())
 
 
 def reload_module(module):

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -52,7 +52,7 @@ models = translation = None
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 29
+TEST_MODELS = 28
 
 # Settings for modeltranslation tests. An additional TEST_APPS setting
 # specifies a list of apps that will be dynamically loaded and have their
@@ -288,7 +288,7 @@ class ModeltranslationTest(ModeltranslationTestBase):
         self.assertTrue(translator)
 
         # Check that all models are registered for translation
-        self.assertEqual(len(translator.get_registered_models()), TEST_MODELS)
+        self.assertEqual(len(translator.get_registered_models(app='tests')), TEST_MODELS)
 
         # Try to unregister a model that is not registered
         self.assertRaises(NotRegistered, translator.unregister, models.BasePage)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -58,6 +58,9 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
     ``related`` attribute inform whether this model is related part of some relation
     with translated model. This model may be not translated itself.
     ``related_fields`` contains names of reverse lookup fields.
+
+    ``default_language`` stores the ``mt_settings.DEFAULT_LANGUAGE`` that was
+    in effect when the model was patched.
     """
     required_languages = ()
 
@@ -71,6 +74,7 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
         self.local_fields = dict((f, set()) for f in self.fields)
         self.fields = dict((f, set()) for f in self.fields)
         self.related_fields = []
+        self.default_language = None
 
     def validate(self):
         """
@@ -387,6 +391,10 @@ class Translator(object):
             # Mark the object explicitly as registered -- registry caches
             # options of all models, registered or not.
             opts.registered = True
+
+            # Remeber the current default language in case it changes to one that
+            # is not available for this field.
+            opts.default_language = mt_settings.DEFAULT_LANGUAGE
 
             # Add translation fields to the model.
             if model._meta.proxy:

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -11,7 +11,7 @@ from modeltranslation.fields import (NONE, create_translation_field, Translation
                                      LanguageCacheSingleObjectDescriptor)
 from modeltranslation.manager import (MultilingualManager, MultilingualQuerysetManager,
                                       rewrite_lookup_key)
-from modeltranslation.utils import build_localized_fieldname, parse_field
+from modeltranslation.utils import build_localized_fieldname, get_app_label, parse_field
 
 
 class AlreadyRegistered(Exception):
@@ -473,13 +473,22 @@ class Translator(object):
                         (desc.__name__, model.__name__))
                 del self._registry[desc]
 
-    def get_registered_models(self, abstract=True):
+    def is_registered(self, model):
         """
-        Returns a list of all registered models, or just concrete
-        registered models.
+        Checks if a model is registered for translation.
         """
-        return [model for (model, opts) in self._registry.items()
-                if opts.registered and (not model._meta.abstract or abstract)]
+        return self._get_options_for_model(model).registered
+
+    def get_registered_models(self, abstract=True, app=None):
+        """
+        Returns a list of all registered models or just concrete registered
+        models, limited to models from an app if it's given.
+        """
+        app_label = get_app_label(app)
+        return [model for (model, opts) in self._registry.items() if
+                opts.registered and
+                (abstract or not model._meta.abstract) and
+                (app is None or model._meta.app_label == app_label)]
 
     def _get_options_for_model(self, model, opts_class=None, **options):
         """

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
 
+import django
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.translation import get_language as _get_language
@@ -20,6 +21,27 @@ def get_language():
     if lang in settings.AVAILABLE_LANGUAGES:
         return lang
     return settings.DEFAULT_LANGUAGE
+
+
+def get_app_label(app):
+    """
+    Returns the label for ``app``. The argument can be:
+    * the app label -- a string;
+    * a pre-1.7 app -- a models module;
+    * a post-1.7 app -- an AppConfig instance;
+    """
+    if django.VERSION >= (1, 7):
+        try:
+            return app.label
+        except AttributeError:
+            return app
+    else:
+        from types import ModuleType
+        if isinstance(app, ModuleType):
+            from django.db.models.loading import cache as app_cache
+            return app_cache._label_for(app)
+        else:
+            return app
 
 
 def get_translation_fields(field):


### PR DESCRIPTION
Note: this is a follow-up to #276, the first 5 commits are exactly the same. The fixes here do depend on the enhancement proposed there, but in case you don't like the command app-selection feature, with some more work it should be possible to work around it.

I've been seeing various failures of the `test_update_command` for some time already, however none of them can be replicated with an empty project. They turned out not to be related to the command itself; rather the test acts as a beacon of side-effects and other quirks as its processing goes over all registered models. The failures fall into 3 categories:
- losing references to classes in `modeltranslation.tests.models` other than models, due to the hard-core reloading during the test base setup; usually apparent as some unexpected `None` during update of one of the custom manager models, for example ([M + MT](https://github.com/wrwrwr/mezzanine/compare/feature/modeltranslation-integration-1.7) + [1.7](https://github.com/django/django/commits/stable/1.7.x)):

```
File "/modeltranslation/tests/models.py", line 266, in get_queryset
    sup = super(CustomManager, self)
TypeError: must be type, not None

File "/modeltranslation/tests/models.py", line 294, in get_queryset
    return CustomQuerySet(self.model, using=self._db)
TypeError: 'NoneType' object is not callable
```
- Update not being effective, due to the command module being loaded before modeltranslation tests setup and sticking to some project's default language ([M + MT](https://github.com/wrwrwr/mezzanine/compare/feature/modeltranslation-integration-1.7) + [1.6](https://github.com/django/django/commits/stable/1.6.x)):

```
File "/modeltranslation/tests/tests.py", line 1903, in test_update_command
    self.assertEqual('initial', obj1.title_de)
AssertionError: 'initial' != u''
```
- Update trying to update user-models registered with project's languages different than the tests set (e.g. same as the last one plus this branch without 1aeaf69):

```
File "/django/db/models/sql/query.py", line 1283, in names_to_path
    "Choices are: %s" % (name, ", ".join(available)))
FieldError: Cannot resolve keyword 'something_de' into field. 
Choices are: <correct translation fields for project's language set>
```

In my experience, while working with the test code it's easy to run into other related issues, most perfidious are those caused by different parts of the system using different copies of `translator`. One hilarious was from an attempt to replace models reloading with lazy registration -- a `NotRegistered` error during `register`.

The idea is to avoid some module reloading in test preparation. The heavy changes are in the first two commits. First, in 9a74829, `reload_app` is asked to clean the translator registry from models that got reloaded, secondly 6c673cd refactors the test base to avoid reloading the translator module.

There is still some reloading left -- of `django.utils.translation` and `modeltranslation.settings`. The first one didn't happen to cause any trouble so far and as long as nothing imports or stores references to objects from modeltranslation settings the implemented module-level reference fixing should be general enough.

The only actual (at least as intended) test changes are in the last two commits: 383fa4b and 1aeaf69.

A nice thing is that with this branch you can run the Mezzanine tests together with modeltranslation suite without any failure, on Django 1.4 - 1.7, with or without South.
