### PR TITLE
Flake8 config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+[flake8]
+max-line-length = 100
+exclude = .tox,docs/modeltranslation/conf.py
+
 [tox]
 distribute = False
 envlist =


### PR DESCRIPTION
Lets you write:

```
flake8
```

instead of

```
flake8 --max-line-length=100 modeltranslation
```

The configuration could also be put into a separate `setup.cfg` file.

That's the last one for now ;-)
