### PR TITLE
Changed MODELTRANSLATION_LANGUAGES example

### DIFF
--- a/docs/modeltranslation/installation.rst
+++ b/docs/modeltranslation/installation.rst
@@ -195,7 +195,7 @@ Example::
         ('de', 'German'),
         ('pl', 'Polish'),
     )
-    MODELTRANSLATION_LANGUAGES = ('en', 'de')
+    MODELTRANSLATION_LANGUAGES = ['en', 'de']
 
 .. note::
     This setting may become useful if your users shall produce content for a restricted


### PR DESCRIPTION
If you use a tuple for this settings, you can get an error here : https://github.com/deschler/django-modeltranslation/blob/master/modeltranslation/utils.py#L48
`settings.AVAILABLE_LANGUAGES` is a tuple and cannot be concatenated with a list.

I guess it could be made clearer that you _have_ to use a list for this settings, or the problem lies in `utils.py`.