### PR TITLE
Fix bug #270

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -388,6 +388,7 @@ class TabbedExternalJqueryTranslationAdmin(TranslationAdmin):
         js = (
             '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js',
             '//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js',
+            '//cdn.jsdelivr.net/jquery.mb.browser/0.1/jquery.mb.browser.min.js',
             'modeltranslation/js/tabbed_translation_fields.js',
         )
         css = {

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -356,6 +356,7 @@ class TabbedDjango15JqueryTranslationAdmin(TranslationAdmin):
         js = (
             'modeltranslation/js/force_jquery.js',
             '//ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js',
+            '//cdn.jsdelivr.net/jquery.mb.browser/0.1/jquery.mb.browser.min.js',
             'modeltranslation/js/tabbed_translation_fields.js',
         )
         css = {
@@ -372,6 +373,7 @@ class TabbedDjangoJqueryTranslationAdmin(TranslationAdmin):
         js = (
             'modeltranslation/js/force_jquery.js',
             '//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js',
+            '//cdn.jsdelivr.net/jquery.mb.browser/0.1/jquery.mb.browser.min.js',
             'modeltranslation/js/tabbed_translation_fields.js',
         )
         css = {


### PR DESCRIPTION
Add ```$.browser``` plugin import to avoid this error: ***Uncaught TypeError: Cannot read property 'msie' of undefined*** since ```$.browser``` was removed from jQuery starting with version 1.9. This error is the cause of page scrolling when changing language tab on an admin field. Tested on Django==1.6.5.