### PR TITLE
Fixed translatable fields discovery with the new _meta API and generic relations

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -130,6 +130,10 @@ def get_fields_to_translatable_models(model):
     if NEW_META_API:
         for f in model._meta.get_fields():
             if f.is_relation and f.related_model:
+                # The new get_field() will find GenericForeignKey relations.
+                # In that case the 'related_model' attribute is set to None
+                # so it is necessary to check for this value before trying to
+                # get translatable fields.
                 if get_translatable_fields_for_model(f.related_model) is not None:
                     results.append((f.name, f.related_model))
     else:

--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -129,7 +129,7 @@ def get_fields_to_translatable_models(model):
     results = []
     if NEW_META_API:
         for f in model._meta.get_fields():
-            if f.is_relation:
+            if f.is_relation and f.related_model:
                 if get_translatable_fields_for_model(f.related_model) is not None:
                     results.append((f.name, f.related_model))
     else:


### PR DESCRIPTION
Hi,

A bug can occur with Django >= 1.8. If a model with translatable field defines a ``GenericForeignKey`` relation, the execution of the ``get_fields_to_translatable_models`` function will fail because the module checks that the ``field.is_relation`` is set to ``True`` but does not check that ``field.related_model`` is not ``None``.

According to the Django documention, the new ``get_field`` method will find ``GenericForeignKey`` relations. So it is necessary to check that the ``related_model`` attribute is not set to ``None`` before using the ``get_translatable_fields_for_model`` function. Otherwise an ``AttributeError`` can be raised.