### PR TITLE
Css improvements

### DIFF
--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -79,11 +79,11 @@ backward compatibility:
     font-family: "Lucida Grande", "DejaVu Sans", "Bitstream Vera Sans", Verdana,Arial, sans-serif;
 }
 .inline-group .tabular tr td {
-    vertical-align: bottom;
+    vertical-align: middle;
 }
 .inline-group .tabular tr.has_original td.original,
 .inline-group .tabular tr td.delete {
-    vertical-align: top;
+    vertical-align: middle;
 }
 
 .inline-group .tabular .datetime > input {

--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -45,6 +45,7 @@ backward compatibility:
 .ui-tabs .ui-tabs-nav li { margin: 0; }
 .ui-tabs .ui-tabs-nav li.required { font-weight: bold; }
 .ui-tabs .ui-tabs-nav li a {
+    outline: none;
     border: 1px solid #CCCCCC;
     background: #eeeeee repeat-x;
     border-bottom-width: 0;


### PR DESCRIPTION
- Changed admin-tabular-inlines vertical-align to middle (it was bottom, and it was very confusing for inlines containing big widgets like TinyMCE)
- Removed the annoying outline added to tab buttons by the browser
  ![schermata 2015-10-02 alle 18 02 19](https://cloud.githubusercontent.com/assets/1035294/10251274/d23d65e2-692f-11e5-8c16-0a22ce3bbae9.png)
