### PR TITLE
Add mt-bidi class to input fields for bi-directional languages.

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -19,7 +19,8 @@ else:
 from modeltranslation import settings as mt_settings
 from modeltranslation.translator import translator
 from modeltranslation.utils import (
-    get_translation_fields, build_css_class, build_localized_fieldname, get_language, unique)
+    get_translation_fields, build_css_class, build_localized_fieldname, get_language, 
+    get_language_bidi, unique)
 from modeltranslation.widgets import ClearableWidgetWrapper
 
 
@@ -80,7 +81,9 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
             css_classes.append('mt')
             # Add localized fieldname css class
             css_classes.append(build_css_class(db_field.name, 'mt-field'))
-
+            # Add mt-bidi css class if language is bidirectional
+            if(get_language_bidi(db_field.language)):
+                css_classes.append('mt-bidi')
             if db_field.language == mt_settings.DEFAULT_LANGUAGE:
                 # Add another css class to identify a default modeltranslation widget
                 css_classes.append('mt-default')

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -19,7 +19,7 @@ else:
 from modeltranslation import settings as mt_settings
 from modeltranslation.translator import translator
 from modeltranslation.utils import (
-    get_translation_fields, build_css_class, build_localized_fieldname, get_language, 
+    get_translation_fields, build_css_class, build_localized_fieldname, get_language,
     get_language_bidi, unique)
 from modeltranslation.widgets import ClearableWidgetWrapper
 

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -24,12 +24,14 @@ def get_language():
         return lang
     return settings.DEFAULT_LANGUAGE
 
+
 def get_language_bidi(lang):
     """
     Check if a language is bi-directional.
     """
     lang_info = get_language_info(lang)
     return lang_info['bidi']
+
 
 def get_translation_fields(field):
     """

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.translation import get_language as _get_language
+from django.utils.translation import get_language_info
 from django.utils.functional import lazy
 
 from modeltranslation import settings
@@ -23,6 +24,12 @@ def get_language():
         return lang
     return settings.DEFAULT_LANGUAGE
 
+def get_language_bidi(lang):
+    """
+    Check if a language is bi-directional.
+    """
+    lang_info = get_language_info(lang)
+    return lang_info['bidi']
 
 def get_translation_fields(field):
     """


### PR DESCRIPTION
Add a css class to distinguish between input fields for ltr and rtl languages, so that the text direction can be changed for all input fields that need to be bi-directional using a css rule:
```css
.mt-bidi {
    direction: rtl;
}
```
