### PR TITLE
`translator.register` as a decorator

### DIFF
--- a/docs/modeltranslation/registration.rst
+++ b/docs/modeltranslation/registration.rst
@@ -50,6 +50,18 @@ only imported. The ``NewsTranslationOptions`` derives from
 ``TranslationOptions`` and provides the ``fields`` attribute. Finally the model
 and its translation options are registered at the ``translator`` object.
 
+If you prefer, ``register`` is also available as a decorator, much like the
+one Django introduced for its admin in version 1.7. Usage is similar to the
+standard ``register``, just provide arguments as you normally would, except 
+the options class which will be the decorated one::
+
+    from modeltranslation.translator import register, TranslationOptions
+    from news.models import News
+
+    @register(News)
+    class NewsTranslationOptions(TranslationOptions):
+        fields = ('title', 'text',)
+
 At this point you are mostly done and the model classes registered for
 translation will have been added some auto-magical fields. The next section
 explains how things are working under the hood.

--- a/modeltranslation/decorators.py
+++ b/modeltranslation/decorators.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+
+def register(model_or_iterable, **options):
+    """
+    Registers the given model(s) with the given translation options.
+
+    The model(s) should be Model classes, not instances.
+
+    Fields declared for translation on a base class are inherited by
+    subclasses. If the model or one of its subclasses is already
+    registered for translation, this will raise an exception.
+
+    @register(Author)
+    class AuthorTranslation(TranslationOptions):
+        pass
+    """
+    from modeltranslation.translator import translator, TranslationOptions
+
+    def wrapper(opts_class):
+        if not issubclass(opts_class, TranslationOptions):
+            raise ValueError('Wrapped class must subclass TranslationOptions.')
+        translator.register(model_or_iterable, opts_class, **options)
+
+    return wrapper

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -307,3 +307,9 @@ class RequiredModel(models.Model):
     req = models.CharField(max_length=10)
     req_reg = models.CharField(max_length=10)
     req_en_reg = models.CharField(max_length=10)
+
+
+# ######### Decorated registration testing
+
+class DecoratedModel(models.Model):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -42,7 +42,7 @@ models = translation = None
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 28
+TEST_MODELS = 29
 
 
 class reload_override_settings(override_settings):

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from django.utils.translation import ugettext_lazy
 
-from modeltranslation.translator import translator, TranslationOptions
+from modeltranslation.translator import translator, register, TranslationOptions
 from modeltranslation.tests.models import (
     TestModel, FallbackModel, FallbackModel2, FileFieldsModel, ForeignKeyModel, OtherFieldsModel,
     DescriptorModel, AbstractModelA, AbstractModelB, Slugged, MetaData, Displayable, Page,
     RichText, RichTextPage, MultitableModelA, MultitableModelB, MultitableModelC, ManagerTestModel,
     CustomManagerTestModel, CustomManager2TestModel, GroupFieldsetsModel, NameModel,
     ThirdPartyRegisteredModel, ProxyTestModel, UniqueNullableModel, OneToOneFieldModel,
-    RequiredModel)
+    RequiredModel, DecoratedModel)
 
 
 class TestTranslationOptions(TranslationOptions):
@@ -196,3 +196,10 @@ class RequiredTranslationOptions(TranslationOptions):
         'default': ('req_reg',),  # for all other languages
     }
 translator.register(RequiredModel, RequiredTranslationOptions)
+
+
+# ######### Decorated registration testing
+
+@register(DecoratedModel)
+class DecoratedTranslationOptions(TranslationOptions):
+    fields = ('title',)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -12,7 +12,6 @@ from modeltranslation.fields import (NONE, create_translation_field, Translation
 from modeltranslation.manager import (MultilingualManager, MultilingualQuerysetManager,
                                       rewrite_lookup_key)
 from modeltranslation.utils import build_localized_fieldname, parse_field
-from modeltranslation.decorators import register
 
 
 class AlreadyRegistered(Exception):
@@ -550,3 +549,7 @@ class Translator(object):
 
 # This global object represents the singleton translator object
 translator = Translator()
+
+
+# Re-export the decorator for convenience
+from modeltranslation.decorators import register  # NOQA re-export

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -12,6 +12,7 @@ from modeltranslation.fields import (NONE, create_translation_field, Translation
 from modeltranslation.manager import (MultilingualManager, MultilingualQuerysetManager,
                                       rewrite_lookup_key)
 from modeltranslation.utils import build_localized_fieldname, parse_field
+from modeltranslation.decorators import register
 
 
 class AlreadyRegistered(Exception):


### PR DESCRIPTION
This patch adds a decorator version of `translator.register`, much like the new `admin.register` decorator introduced in Django 1.7, on which it is based.

The decorator is available in `decorators.py`, and also imported in `translator.py` for convenience during import. It accepts the same arguments as `register`. Tests and docs are of course provided.

~~~py
from modeltranslation.translator import register, TranslationOptions
from news.models import News

@register(News)
class NewsTranslationOptions(TranslationOptions):
    fields = ('title', 'text',)
~~~