### PR TITLE
Handle annotation fields when using values_list

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -445,14 +445,21 @@ class FallbackValuesQuerySet(models.query.ValuesQuerySet, MultilingualQuerySet):
 
 class FallbackValuesListQuerySet(FallbackValuesQuerySet):
     def iterator(self):
+        fields = self.original_fields
+        if hasattr(self, 'aggregate_names'):
+            # Django <1.8
+            fields += tuple(self.aggregate_names)
+        if hasattr(self, 'annotation_names'):
+            # Django >=1.8
+            fields += tuple(self.annotation_names)
         for row in super(FallbackValuesListQuerySet, self).iterator():
-            if self.flat and len(self.original_fields) == 1:
-                yield row[self.original_fields[0]]
+            if self.flat and len(fields) == 1:
+                yield row[fields[0]]
             else:
-                yield tuple(row[f] for f in self.original_fields)
+                yield tuple(row[f] for f in fields)
 
     def _setup_query(self):
-        self.original_fields = self._fields
+        self.original_fields = tuple(self._fields)
         super(FallbackValuesListQuerySet, self)._setup_query()
 
     def _clone(self, *args, **kwargs):

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -14,7 +14,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.management import call_command
 from django.db import IntegrityError
-from django.db.models import Q, F
+from django.db.models import Q, F, Count
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils import six
@@ -2550,6 +2550,14 @@ class TestManager(ModeltranslationTestBase):
              'visits': 0, 'visits_en': 0, 'visits_de': 0,
              'description': None, 'description_en': None, 'description_de': None},
         ])
+
+    def test_values_list_annotation(self):
+        models.TestModel(title='foo').save()
+        models.TestModel(title='foo').save()
+        self.assertEqual(
+            list(models.TestModel.objects.all().values_list('title').annotate(Count('id'))),
+            [('foo', 2)]
+        )
 
     def test_custom_manager(self):
         """Test if user-defined manager is still working"""


### PR DESCRIPTION
I recently tried to upgrade a project from v0.8b2 to v0.9.1 and ran into an issue regarding using annotate with values_list. The annotated values are lost.

The made up queryset `Foo.objects.values_list('field').annotate(Count('id'))` used to return `[('foo', 10), ...]` but as of v0.8 the returned value will be `[('foo', ), ...]`

This pull request contains one possible solution and a test case.