### PR TITLE
update_translation_fields: Support unmanaged models

### DIFF
--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from optparse import make_option
+
 from django.db.models import F, Q
 from django.core.management.base import NoArgsCommand
 
@@ -11,11 +13,20 @@ class Command(NoArgsCommand):
     help = ('Updates empty values of default translation fields using'
             ' values from original fields (in all translated models).')
 
+    option_list = NoArgsCommand.option_list + (
+        make_option('--managed-only',
+                    action='store_true',
+                    dest='managed_only',
+                    default=False,
+                    help='Only update managed models'),
+    )
+
     def handle_noargs(self, **options):
         verbosity = int(options['verbosity'])
         if verbosity > 0:
             self.stdout.write("Using default language: %s\n" % DEFAULT_LANGUAGE)
-        models = translator.get_registered_models(abstract=False)
+        unmanaged = not options['managed_only']
+        models = translator.get_registered_models(abstract=False, unmanaged=unmanaged)
         for model in models:
             if verbosity > 0:
                 self.stdout.write("Updating data of model '%s'\n" % model)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -500,13 +500,14 @@ class Translator(object):
                         (desc.__name__, model.__name__))
                 del self._registry[desc]
 
-    def get_registered_models(self, abstract=True):
+    def get_registered_models(self, abstract=True, unmanaged=True):
         """
         Returns a list of all registered models, or just concrete
         registered models.
         """
         return [model for (model, opts) in self._registry.items()
-                if opts.registered and (not model._meta.abstract or abstract)]
+                if opts.registered and (not model._meta.abstract or abstract)
+                and (model._meta.managed or unmanaged)]
 
     def _get_options_for_model(self, model, opts_class=None, **options):
         """


### PR DESCRIPTION
Add an option to update_translation_fields to skip unmanaged models. This is useful when models in an external database should be left untouched.
