### PR TITLE
fix proxy model inheritance for django >=1.8

### DIFF
--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -304,6 +304,9 @@ def delete_cache_fields(model):
         except AttributeError:
             pass
 
+    if hasattr(model._meta, '_expire_cache'):
+        model._meta._expire_cache()
+
 
 def populate_translation_fields(sender, kwargs):
     """


### PR DESCRIPTION
This fixes #304 for proxy models ([context](https://github.com/deschler/django-modeltranslation/issues/304#issuecomment-146265312)).

I tried to add a test case to demonstrate the problem, but unfortunately some complications in `ModeltranslationTransactionTestBase`'s `setUpClass` prevented my from doing so.

The problem is that the translation options in translation.py are registered twice, once in the [super call](https://github.com/deschler/django-modeltranslation/blob/3df9d3e5d3f2fc092168789cbcab00c3942ae9fa/modeltranslation/tests/tests.py#L86) (which ends up calling `AppConfig.ready`) and once [explicitly](https://github.com/deschler/django-modeltranslation/blob/3df9d3e5d3f2fc092168789cbcab00c3942ae9fa/modeltranslation/tests/tests.py#L116). The second registration makes the issue go away, but outside the test suite the translations are registered once so the bug is still there.

The only way I found to verify the issue is to add something like `print(ProxyTestModel._meta.concrete_fields)` [here](https://github.com/deschler/django-modeltranslation/blob/3df9d3e5d3f2fc092168789cbcab00c3942ae9fa/modeltranslation/tests/translation.py#L30) and manually check the first line of the output (corresponding to the first registration). [Here](https://gist.github.com/anonymous/f6d1bd22d5ee00a75878) is what I get before and after my patch.