### PR TITLE
let register decorator return decorated class

### DIFF
--- a/modeltranslation/decorators.py
+++ b/modeltranslation/decorators.py
@@ -21,5 +21,6 @@ def register(model_or_iterable, **options):
         if not issubclass(opts_class, TranslationOptions):
             raise ValueError('Wrapped class must subclass TranslationOptions.')
         translator.register(model_or_iterable, opts_class, **options)
+        return opts_class
 
     return wrapper


### PR DESCRIPTION
This way we preserve TranslationOptions subclass around in our module (and that's how decorators are supposed to work in the first place).

Thanks for magnificent app!