### PR TITLE
Works with collapsed admin elements

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -213,7 +213,7 @@ var google, django, gettext;
             this.getAllGroupedTranslations = function () {
                 var grouper = new TranslationFieldGrouper({
                     $fields: this.$table.find('.mt').filter(
-                        'input:visible, textarea:visible, select:visible')
+                        'input, textarea, select')
                 });
                 //this.requiredColumns = this.getRequiredColumns();
                 this.initTable();


### PR DESCRIPTION
Tabs would not be initialized for fields inside a "collapsed" admin fieldset. This is meant to correct this.
