### PR TITLE
Fix test failures when django directory is not writable

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import shutil
 import sys
 
 import django
@@ -40,12 +41,25 @@ def runtests():
                 'django.contrib.auth',
                 'modeltranslation',
             ),
+            MIGRATION_MODULES={
+                'auth': 'modeltranslation.tests.auth_migrations',
+            },
             ROOT_URLCONF=None,  # tests override urlconf, but it still needs to be defined
             LANGUAGES=(
                 ('en', 'English'),
             ),
             MIDDLEWARE_CLASSES=(),
         )
+
+    # Copy django.contrib.auth.migrations to a writable path
+    dj_auth_migrations_dir = os.path.join(os.path.dirname(django.__file__),
+                                          'contrib', 'auth', 'migrations')
+    auth_migrations_dir = os.path.join('modeltranslation', 'tests',
+                                       'auth_migrations')
+    if os.path.exists(dj_auth_migrations_dir):
+        if os.path.isdir(auth_migrations_dir):
+            shutil.rmtree(auth_migrations_dir)
+        shutil.copytree(dj_auth_migrations_dir, auth_migrations_dir)
 
     if django.VERSION >= (1, 7):
         django.setup()


### PR DESCRIPTION
The tests modify the Group model exported by the django.contrib.auth
application and as such, when makemigrations is called, it wants to create
a new file in django/contrib/auth/migrations. This fails when the
directory is not writable, as is the case for a typical system-wide
installation (with a Debian package in my case).

To avoid this problem, we modify the test runner to set the
MIGRATION_MODULES django setting so that the migrations for the auth
application are looked up in the “modeltranslation.tests.auth_migrations”
package and we initialize that package with the migrations found
in the django directory.

Fix #377. This patch has been tested with Django 1.9.7.