### PR TITLE
Feature: filtering and annotating querysets by translation status

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -271,6 +271,7 @@ class ManagerCheckTransTestModel(models.Model):
     class Meta:
         ordering = ('-visits',)
 
+
 class ManagerCheckTrans2TestModel(models.Model):
     # Model with non-required (i.e. blank=True) translation fields.
     # Required field 'title' is not registered for translation

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -261,6 +261,26 @@ class ManagerTestModel(models.Model):
         ordering = ('-visits',)
 
 
+class ManagerCheckTransTestModel(models.Model):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    visits = models.IntegerField(ugettext_lazy('visits'), default=0)
+    description = models.CharField(max_length=255, null=True)
+    verified = models.BooleanField(ugettext_lazy('title'), default=True, blank=True)
+    subtitle = models.CharField(ugettext_lazy('title'), max_length=255, default='', blank=True)
+
+    class Meta:
+        ordering = ('-visits',)
+
+class ManagerCheckTrans2TestModel(models.Model):
+    # Model with non-required (i.e. blank=True) translation fields.
+    # Required field 'title' is not registered for translation
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    visits = models.IntegerField(ugettext_lazy('visits'), blank=True)
+    description = models.CharField(max_length=255, null=True, blank=True)
+    verified = models.BooleanField(ugettext_lazy('title'), default=True, blank=True)
+    subtitle = models.CharField(ugettext_lazy('title'), max_length=255, default='', blank=True)
+
+
 class CustomManager(models.Manager):
     def get_queryset(self):
         sup = super(CustomManager, self)

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -265,8 +265,8 @@ class ManagerCheckTransTestModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
     visits = models.IntegerField(ugettext_lazy('visits'), default=0)
     description = models.CharField(max_length=255, null=True)
-    verified = models.BooleanField(ugettext_lazy('title'), default=True, blank=True)
-    subtitle = models.CharField(ugettext_lazy('title'), max_length=255, default='', blank=True)
+    verified = models.BooleanField(ugettext_lazy('verified'), default=True, blank=True)
+    subtitle = models.CharField(ugettext_lazy('subtitle'), max_length=255, default='', blank=True)
 
     class Meta:
         ordering = ('-visits',)
@@ -277,8 +277,8 @@ class ManagerCheckTrans2TestModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
     visits = models.IntegerField(ugettext_lazy('visits'), null=True, blank=True)
     description = models.CharField(max_length=255, null=True, blank=True)
-    verified = models.BooleanField(ugettext_lazy('title'), default=True, blank=True)
-    subtitle = models.CharField(ugettext_lazy('title'), max_length=255, default='', blank=True)
+    verified = models.BooleanField(ugettext_lazy('verified'), null=True, blank=True)
+    subtitle = models.CharField(ugettext_lazy('subtitle'), max_length=255, default='', blank=True)
 
 
 class CustomManager(models.Manager):

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -275,7 +275,7 @@ class ManagerCheckTrans2TestModel(models.Model):
     # Model with non-required (i.e. blank=True) translation fields.
     # Required field 'title' is not registered for translation
     title = models.CharField(ugettext_lazy('title'), max_length=255)
-    visits = models.IntegerField(ugettext_lazy('visits'), blank=True)
+    visits = models.IntegerField(ugettext_lazy('visits'), null=True, blank=True)
     description = models.CharField(max_length=255, null=True, blank=True)
     verified = models.BooleanField(ugettext_lazy('title'), default=True, blank=True)
     subtitle = models.CharField(ugettext_lazy('title'), max_length=255, default='', blank=True)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2945,24 +2945,23 @@ class TestManager(ModeltranslationTestBase):
 
 class TestManagerTranslationCheck(TestManager):
     """
-    If model has registered required (i.e. blank=False) fields then if ANY of required
-    translation field values of an instance is empty (including '' for text fields),
-    the instance is considered untranslated. Values of non-required fields (blank=True)
+    If model has registered required (i.e. blank=False) fields then if all required
+    translation field values of an instance are non-empty,
+    the instance is considered translated. Values of non-required fields (blank=True)
     are ignored in this case.
-    If all fields registered for translation are non-required, then instance
-    is considered untranslated if ALL field values are empty.
+    If all fields registered for translation are non-required, then the instance
+    is considered translated if any field value is non-empty.
 
-    If field default is other than '', it is considered as translated.
-    Boolean fields are ignored for check.
-
+    Boolean fields are ignored. Of course, we might have such very rare (and unimaginable)
+    case when we have only one required translation Boolean field, and if we ignore it for check,
+    then the instance will be considered translated if any non-required field is not empty.
     """
 
     def setUp(self):
         super(TestManagerTranslationCheck, self).setUp()
 
         # For ManagerCheckTransTestModel only fields 'title', 'visits', 'description'
-        # should be checked as they have blank=False. Moreover, as 'visits' has default=0 (not ''),
-        # it is considered as translated.
+        # should be checked as they have blank=False.
 
         # Untranslated in en as 'description' is ''
         # Untranslated in de as 'description' is '' and 'title_de' is ''
@@ -3007,7 +3006,8 @@ class TestManagerTranslationCheck(TestManager):
         m5.save()
 
         # Registered translation fields of ManagerCheckTrans2TestModel are all non-required.
-        # So fields 'visits', 'description', 'verified', 'subtitle' should be checked
+        # So fields 'visits', 'description', 'subtitle' should be checked.
+        # 'verified' is Boolean and so is ignored.
         # Required field 'title' is not registered for translation so it is ignored.
 
         # Untranslated in en

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -3053,62 +3053,63 @@ class TestManagerTranslationCheck(TestManager):
         """
         self.assertEqual('en', get_language())
 
-        self.assertEqual(3, models.ManagerCheckTransTestModel.objects.filter_translated().count())
-        self.assertEqual(3, models.ManagerCheckTransTestModel.objects.filter_translated(lang='en').count())
-        self.assertEqual(2, models.ManagerCheckTransTestModel.objects.filter_translated(lang='de').count())
+        m_objects = models.ManagerCheckTransTestModel.objects
+        n_objects = models.ManagerCheckTrans2TestModel.objects
 
-        self.assertEqual(3, models.ManagerCheckTrans2TestModel.objects.filter_translated().count())
-        self.assertEqual(3, models.ManagerCheckTrans2TestModel.objects.filter_translated(lang='en').count())
-        self.assertEqual(2, models.ManagerCheckTrans2TestModel.objects.filter_translated(lang='de').count())
+        self.assertEqual(3, m_objects.filter_translated().count())
+        self.assertEqual(3, m_objects.filter_translated(lang='en').count())
+        self.assertEqual(2, m_objects.filter_translated(lang='de').count())
+        self.assertEqual(3, n_objects.filter_translated().count())
+        self.assertEqual(3, n_objects.filter_translated(lang='en').count())
+        self.assertEqual(2, n_objects.filter_translated(lang='de').count())
 
-        m_qs = models.ManagerCheckTransTestModel.objects.exclude(title__contains='m4')
+        m_qs = m_objects.exclude(title__contains='m4')
         self.assertEqual(2, m_qs.filter_translated().count())
         self.assertEqual(2, m_qs.filter_translated(lang='en').count())
         self.assertEqual(1, m_qs.filter_translated(lang='de').count())
-
-        n_qs = models.ManagerCheckTrans2TestModel.objects.exclude(title='condition')
+        n_qs = n_objects.exclude(title='condition')
         self.assertEqual(2, n_qs.filter_translated().count())
         self.assertEqual(2, n_qs.filter_translated(lang='en').count())
         self.assertEqual(1, n_qs.filter_translated(lang='de').count())
 
         with override('de'):
-            self.assertEqual(2, models.ManagerCheckTransTestModel.objects.filter_translated().count())
-            self.assertEqual(3, models.ManagerCheckTransTestModel.objects.filter_translated(lang='en').count())
-            self.assertEqual(2, models.ManagerCheckTransTestModel.objects.filter_translated(lang='de').count())
+            self.assertEqual(2, m_objects.filter_translated().count())
+            self.assertEqual(3, m_objects.filter_translated(lang='en').count())
+            self.assertEqual(2, m_objects.filter_translated(lang='de').count())
+            self.assertEqual(2, n_objects.filter_translated().count())
+            self.assertEqual(3, n_objects.filter_translated(lang='en').count())
+            self.assertEqual(2, n_objects.filter_translated(lang='de').count())
 
-            self.assertEqual(2, models.ManagerCheckTrans2TestModel.objects.filter_translated().count())
-            self.assertEqual(3, models.ManagerCheckTrans2TestModel.objects.filter_translated(lang='en').count())
-            self.assertEqual(2, models.ManagerCheckTrans2TestModel.objects.filter_translated(lang='de').count())
-
-            m_qs = models.ManagerCheckTransTestModel.objects.exclude(title__contains='m4')
+            m_qs = m_objects.exclude(title__contains='m4')
             self.assertEqual(1, m_qs.filter_translated().count())
             self.assertEqual(2, m_qs.filter_translated(lang='en').count())
             self.assertEqual(1, m_qs.filter_translated(lang='de').count())
-
-            n_qs = models.ManagerCheckTrans2TestModel.objects.exclude(title='condition')
+            n_qs = n_objects.exclude(title='condition')
             self.assertEqual(1, n_qs.filter_translated().count())
             self.assertEqual(2, n_qs.filter_translated(lang='en').count())
             self.assertEqual(1, n_qs.filter_translated(lang='de').count())
 
-
     def test_annotate_translated(self):
         """
         Test if queryset is annotated with translation status for the specified language
-
         """
         self.assertEqual('en', get_language())
+        m_objects = models.ManagerCheckTransTestModel.objects
+        n_objects = models.ManagerCheckTrans2TestModel.objects
 
-        self.assertEqual(5, models.ManagerCheckTrans2TestModel.objects.annotate_translated().count())
-        self.assertEqual(5, models.ManagerCheckTrans2TestModel.objects.annotate_translated(lang='en').count())
-        self.assertEqual(5, models.ManagerCheckTrans2TestModel.objects.annotate_translated(lang='de').count())
+        self.assertEqual(5, m_objects.annotate_translated().count())
+        self.assertEqual(5, m_objects.annotate_translated(lang='en').count())
+        self.assertEqual(5, m_objects.annotate_translated(lang='de').count())
+        self.assertEqual(5, n_objects.annotate_translated().count())
+        self.assertEqual(5, n_objects.annotate_translated(lang='en').count())
+        self.assertEqual(5, n_objects.annotate_translated(lang='de').count())
 
-        m_qs = models.ManagerCheckTransTestModel.objects.exclude(title__contains='m4')
+        m_qs = m_objects.exclude(title__contains='m4')
         self.assertEqual(4, m_qs.annotate_translated().count())
-
-        n_qs = models.ManagerCheckTrans2TestModel.objects.exclude(title='condition')
+        n_qs = n_objects.exclude(title='condition')
         self.assertEqual(4, n_qs.annotate_translated().count())
 
-        m_qs_all = models.ManagerCheckTransTestModel.objects.all()
+        m_qs_all = m_objects.all()
 
         qs_en_annotated = m_qs_all.annotate_translated(lang='en')
         m2_en = qs_en_annotated.get(title_en='m2 en title')
@@ -3122,7 +3123,7 @@ class TestManagerTranslationCheck(TestManager):
         m3_de = qs_de_annotated.get(title_en='m3 en title')
         self.assertTrue(m3_de.translated)
 
-        n_qs_all = models.ManagerCheckTrans2TestModel.objects.all()
+        n_qs_all = n_objects.all()
 
         qs_en_annotated = n_qs_all.annotate_translated(lang='en')
         n2_en = qs_en_annotated.get(title='n2 title')
@@ -3137,42 +3138,39 @@ class TestManagerTranslationCheck(TestManager):
         self.assertTrue(n3_de.translated)
 
         with override('de'):
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated().count())
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated(lang='en').count())
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated(lang='de').count())
+            self.assertEqual(5, m_objects.annotate_translated().count())
+            self.assertEqual(5, m_objects.annotate_translated(lang='en').count())
+            self.assertEqual(5, m_objects.annotate_translated(lang='de').count())
+            self.assertEqual(5, n_objects.annotate_translated().count())
+            self.assertEqual(5, n_objects.annotate_translated(lang='en').count())
+            self.assertEqual(5, n_objects.annotate_translated(lang='de').count())
 
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated().count())
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated(lang='en').count())
-            self.assertEqual(5, models.ManagerCheckTransTestModel.objects.annotate_translated(lang='de').count())
-
-            m_qs = models.ManagerCheckTransTestModel.objects.exclude(title__contains='m4')
+            m_qs = m_objects.exclude(title__contains='m4')
             self.assertEqual(4, m_qs.annotate_translated().count())
 
-            n_qs = models.ManagerCheckTrans2TestModel.objects.exclude(title='condition')
+            n_qs = n_objects.exclude(title='condition')
             self.assertEqual(4, n_qs.annotate_translated().count())
 
-            m_qs_all = models.ManagerCheckTransTestModel.objects.all()
+            m_qs_all = m_objects.all()
 
             qs_en_annotated = m_qs_all.annotate_translated(lang='en')
             m2_en = qs_en_annotated.get(title_en='m2 en title')
             self.assertTrue(m2_en.translated)
             m3_en = qs_en_annotated.get(title_en='m3 en title')
             self.assertFalse(m3_en.translated)
-
             qs_de_annotated = m_qs_all.annotate_translated(lang='de')
             m2_de = qs_de_annotated.get(title_en='m2 en title')
             self.assertFalse(m2_de.translated)
             m3_de = qs_de_annotated.get(title_en='m3 en title')
             self.assertTrue(m3_de.translated)
 
-            n_qs_all = models.ManagerCheckTrans2TestModel.objects.all()
+            n_qs_all = n_objects.all()
 
             qs_en_annotated = n_qs_all.annotate_translated(lang='en')
             n2_en = qs_en_annotated.get(title='n2 title')
             self.assertTrue(n2_en.translated)
             n3_en = qs_en_annotated.get(title='n3 title')
             self.assertFalse(n3_en.translated)
-
             qs_de_annotated = n_qs_all.annotate_translated(lang='de')
             n2_de = qs_de_annotated.get(title='n2 title')
             self.assertFalse(n2_de.translated)

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -7,6 +7,7 @@ from modeltranslation.tests.models import (
     TestModel, FallbackModel, FallbackModel2, FileFieldsModel, ForeignKeyModel, OtherFieldsModel,
     DescriptorModel, AbstractModelA, AbstractModelB, Slugged, MetaData, Displayable, Page,
     RichText, RichTextPage, MultitableModelA, MultitableModelB, MultitableModelC, ManagerTestModel,
+    ManagerCheckTransTestModel, ManagerCheckTrans2TestModel,
     CustomManagerTestModel, CustomManager2TestModel, GroupFieldsetsModel, NameModel,
     ThirdPartyRegisteredModel, ProxyTestModel, UniqueNullableModel, OneToOneFieldModel,
     RequiredModel, DecoratedModel)
@@ -138,6 +139,16 @@ translator.register(RichTextPage)
 class ManagerTestModelTranslationOptions(TranslationOptions):
     fields = ('title', 'visits', 'description')
 translator.register(ManagerTestModel, ManagerTestModelTranslationOptions)
+
+
+class ManagerCheckTransTestModelTranslationOptions(TranslationOptions):
+    fields = ('title', 'visits', 'description', 'verified', 'subtitle')
+translator.register(ManagerCheckTransTestModel, ManagerCheckTransTestModelTranslationOptions)
+
+
+class ManagerCheckTrans2TestModelTranslationOptions(TranslationOptions):
+    fields = ('visits', 'description', 'verified', 'subtitle')
+translator.register(ManagerCheckTrans2TestModel, ManagerCheckTrans2TestModelTranslationOptions)
 
 
 class CustomManagerTestModelTranslationOptions(TranslationOptions):


### PR DESCRIPTION
Sometimes it is handy to get only translated instances in a specified language or be able to check translation status of each instance in the queryset.

Two methods for MultilingualManager (and MultilingualQuerySet) are proposed:
- `filter_translated()`
- `annotate_translated()`
