### PR TITLE
Fix order_by with expression

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -120,7 +120,15 @@ def append_lookup_key(model, lookup_key):
 
 
 def append_lookup_keys(model, fields):
-    return moves.reduce(set.union, (append_lookup_key(model, field) for field in fields), set())
+    new_fields = []
+    for field in fields:
+        try:
+            new_field = append_lookup_key(model, field)
+        except AttributeError:
+            new_field = (field,)
+        new_fields.append(new_field)
+
+    return moves.reduce(set.union, new_fields, set())
 
 
 def rewrite_order_lookup_key(model, lookup_key):

--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -351,7 +351,11 @@ class MultilingualQuerySet(models.query.QuerySet):
             return super(MultilingualQuerySet, self).order_by(*field_names)
         new_args = []
         for key in field_names:
-            new_args.append(rewrite_order_lookup_key(self.model, key))
+            try:
+                new_arg = rewrite_order_lookup_key(self.model, key)
+            except AttributeError:
+                new_arg = key
+            new_args.append(new_arg)
         return super(MultilingualQuerySet, self).order_by(*new_args)
 
     def update(self, **kwargs):


### PR DESCRIPTION
Fix #375 

 1. The fix could be moved within `rewrite_order_lookup_key` function
 2. I chose a try: except: approach but we could check if it's a string