### PR TITLE
FALLBACK_LANGUAGES['default'] needs to be tuple

### DIFF
--- a/modeltranslation/settings.py
+++ b/modeltranslation/settings.py
@@ -36,7 +36,7 @@ AUTO_POPULATE = getattr(settings, 'MODELTRANSLATION_AUTO_POPULATE', False)
 # By default we fallback to the default language
 FALLBACK_LANGUAGES = getattr(settings, 'MODELTRANSLATION_FALLBACK_LANGUAGES', (DEFAULT_LANGUAGE,))
 if isinstance(FALLBACK_LANGUAGES, (tuple, list)):
-    FALLBACK_LANGUAGES = {'default': FALLBACK_LANGUAGES}
+    FALLBACK_LANGUAGES = {'default': tuple(FALLBACK_LANGUAGES)}
 if 'default' not in FALLBACK_LANGUAGES:
     raise ImproperlyConfigured(
         'MODELTRANSLATION_FALLBACK_LANGUAGES does not contain "default" key.')


### PR DESCRIPTION
if `MODELTRANSLATION_FALLBACK_LANGUAGES` in django's `settings.py` is a list (as explicitly accepted by `modeltranslation/settings.py`), following code point throws `TypeError: can only concatenate tuple (not "list") to tuple`:

[modeltranslation/utils.py#L116f.](https://github.com/deschler/django-modeltranslation/blob/master/modeltranslation/utils.py#L117)
```
def resolution_order(lang, override=None):
  ... ...
    fallback_def = override.get('default', settings.FALLBACK_LANGUAGES['default'])
    order = (lang,) + fallback_for_lang + fallback_def
```

`fallback_def` and hence `settings.FALLBACK_LANGUAGES['default']` needs to be a tuple.

This PR proposes to transparently ensure it is a tuple (no change in usage / user docu needed).