### PR TITLE
Django 2.0 deprecation warnings.

### DIFF
--- a/modeltranslation/fields.py
+++ b/modeltranslation/fields.py
@@ -182,8 +182,8 @@ class TranslationField(object):
                 self.related_query_name = lambda: loc_related_query_name
             self.remote_field.related_name = build_localized_fieldname(current, self.language)
             self.remote_field.field = self  # Django 1.6
-            if hasattr(self.remote_field.to._meta, '_related_objects_cache'):
-                del self.remote_field.to._meta._related_objects_cache
+            if hasattr(self.remote_field.model._meta, '_related_objects_cache'):
+                del self.remote_field.model._meta._related_objects_cache
 
     # Django 1.5 changed definition of __hash__ for fields to be fine with hash requirements.
     # It spoiled our machinery, since TranslationField has the same creation_counter as its

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -60,19 +60,31 @@ class NonTranslated(models.Model):
 
 class ForeignKeyModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
-    test = models.ForeignKey(TestModel, null=True, related_name="test_fks")
-    optional = models.ForeignKey(TestModel, blank=True, null=True)
-    hidden = models.ForeignKey(TestModel, blank=True, null=True, related_name="+")
-    non = models.ForeignKey(NonTranslated, blank=True, null=True, related_name="test_fks")
-    untrans = models.ForeignKey(TestModel, blank=True, null=True, related_name="test_fks_un")
+    test = models.ForeignKey(
+        TestModel, null=True, related_name="test_fks", on_delete=models.CASCADE,
+    )
+    optional = models.ForeignKey(TestModel, blank=True, null=True, on_delete=models.CASCADE)
+    hidden = models.ForeignKey(
+        TestModel, blank=True, null=True, related_name="+", on_delete=models.CASCADE,
+    )
+    non = models.ForeignKey(
+        NonTranslated, blank=True, null=True, related_name="test_fks", on_delete=models.CASCADE,
+    )
+    untrans = models.ForeignKey(
+        TestModel, blank=True, null=True, related_name="test_fks_un", on_delete=models.CASCADE,
+    )
 
 
 class OneToOneFieldModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
-    test = models.OneToOneField(TestModel, null=True, related_name="test_o2o")
-    optional = models.OneToOneField(TestModel, blank=True, null=True)
+    test = models.OneToOneField(
+        TestModel, null=True, related_name="test_o2o", on_delete=models.CASCADE,
+    )
+    optional = models.OneToOneField(TestModel, blank=True, null=True, on_delete=models.CASCADE)
     # No hidden option for OneToOne
-    non = models.OneToOneField(NonTranslated, blank=True, null=True, related_name="test_o2o")
+    non = models.OneToOneField(
+        NonTranslated, blank=True, null=True, related_name="test_o2o", on_delete=models.CASCADE,
+    )
 
 
 # ######### Custom fields testing

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -989,9 +989,12 @@ class ForeignKeyFieldsTest(ModeltranslationTestBase):
         trans_real.activate("de")
         test_inst2 = models.TestModel(title_en='title_en', title_de='title_de')
         test_inst2.save()
-        test_inst2.test_fks = [fk_inst_de, fk_inst_both]
-        test_inst2.test_fks_en = (fk_inst_en, fk_inst_both)
-
+        if django.VERSION >= (1, 9):
+            test_inst2.test_fks.set((fk_inst_de, fk_inst_both))
+            test_inst2.test_fks_en.set((fk_inst_en, fk_inst_both))
+        else:
+            test_inst2.test_fks = [fk_inst_de, fk_inst_both]
+            test_inst2.test_fks_en = (fk_inst_en, fk_inst_both)
         self.assertEqual(fk_inst_both.test.pk, test_inst2.pk)
         self.assertEqual(fk_inst_both.test_id, test_inst2.pk)
         self.assertEqual(fk_inst_both.test_de, test_inst2)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -529,11 +529,11 @@ class Translator(object):
 
                 # Set related field names on other model
                 if NEW_RELATED_API and not field.remote_field.is_hidden():
-                    other_opts = self._get_options_for_model(field.remote_field.to)
+                    other_opts = self._get_options_for_model(field.remote_field.model)
                     other_opts.related = True
                     other_opts.related_fields.append(field.related_query_name())
                     # Add manager in case of non-registered model
-                    add_manager(field.remote_field.to)
+                    add_manager(field.remote_field.model)
                 elif not NEW_RELATED_API and not field.rel.is_hidden():
                     other_opts = self._get_options_for_model(field.rel.to)
                     other_opts.related = True
@@ -543,7 +543,7 @@ class Translator(object):
             if isinstance(field, OneToOneField):
                 # Fix translated_field caching for SingleRelatedObjectDescriptor
                 sro_descriptor = (
-                    getattr(field.remote_field.to, field.remote_field.get_accessor_name())
+                    getattr(field.remote_field.model, field.remote_field.get_accessor_name())
                     if NEW_RELATED_API
                     else getattr(field.rel.to, field.related.get_accessor_name()))
                 patch_related_object_descriptor_caching(sro_descriptor)

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
 
 import django
 from django.conf import settings
@@ -47,6 +48,7 @@ def runtests():
             MIDDLEWARE_CLASSES=(),
         )
 
+    warnings.simplefilter('always', DeprecationWarning)
     if django.VERSION >= (1, 7):
         django.setup()
     failures = call_command(


### PR DESCRIPTION
I added `DeprecationWarning` display and I fixed most of them, i.e.:
* *RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior. See https://docs.djangoproject.com/en/1.11/ref/models/fields/#django.db.models.ForeignKey.on_delete*,
* *RemovedInDjango20Warning: Direct assignment to the reverse side of a related set is deprecated due to the implicit save() that happens. Use sth.set() instead.*,
* *RemovedInDjango20Warning: Usage of ForeignObjectRel.to attribute has been deprecated. Use the model attribute instead.*.

I will fix the last one in a separate PR: *RemovedInDjango20Warning: use_for_related_fields is deprecated, instead set Meta.base_manager_name on sth'*.
