### PR TITLE
Used Meta.base_manager_name on model instead of Manager.use_for_related_fields.

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -7,6 +7,7 @@ https://github.com/zmathew/django-linguo
 """
 import itertools
 
+import django
 from django.db import models
 from django.db.models import FieldDoesNotExist
 try:
@@ -570,7 +571,8 @@ class MultilingualQuerysetManager(models.Manager):
 
 
 class MultilingualManager(MultilingualQuerysetManager):
-    use_for_related_fields = True
+    if django.VERSION < (1, 10):
+        use_for_related_fields = True
 
     def rewrite(self, *args, **kwargs):
         return self.get_queryset().rewrite(*args, **kwargs)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -194,8 +194,12 @@ def add_manager(model):
         else:
             class NewMultilingualManager(MultilingualManager, manager.__class__,
                                          MultilingualQuerysetManager):
-                use_for_related_fields = getattr(
-                    manager.__class__, "use_for_related_fields", not has_custom_queryset(manager))
+                if VERSION < (1, 10):
+                    use_for_related_fields = getattr(
+                        manager.__class__,
+                        "use_for_related_fields",
+                        not has_custom_queryset(manager),
+                    )
                 _old_module = manager.__module__
                 _old_class = manager.__class__.__name__
 
@@ -224,6 +228,8 @@ def add_manager(model):
             # share the same class.
             model._default_manager.__class__ = current_manager.__class__
     patch_manager_class(model._base_manager)
+    if VERSION >= (1, 10):
+        model._meta.base_manager_name = 'objects'
     if hasattr(model._meta, "_expire_cache"):
         model._meta._expire_cache()
 


### PR DESCRIPTION
I fixed *"RemovedInDjango20Warning: use_for_related_fields is deprecated, instead set Meta.base_manager_name on sth"*.