### PR TITLE
Make it work if the admin are divided by tabs

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -392,7 +392,7 @@ var google, django, gettext;
             // Group normal fields and fields in (existing) stacked inlines
             var grouper = new TranslationFieldGrouper({
                 $fields: $('.mt').filter(
-                    'input:visible, textarea:visible, select:visible, iframe, div').filter(':parents(.tabular)')
+                    'input, textarea, select, iframe, div').filter(':parents(.tabular)')
             });
             MainSwitch.init(grouper.groupedTranslations, createTabs(grouper.groupedTranslations));
 


### PR DESCRIPTION
Hi, i'm using a package django-jet on a project that changes the admin. It has a feature that divides the form with tabs, if I change the tab or click the on the button "save and continue editing" when I change the tab the translated fields don't group in tabs.

If you think this feature is too much coupled to a package, but i think it have more packages like that, please decline and say.

Best,
Hélio