### PR TITLE
Get related model from field's path_info

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -8,7 +8,11 @@ https://github.com/zmathew/django-linguo
 import itertools
 
 import django
-from django.contrib.admin.utils import get_model_from_relation
+try:
+    from django.contrib.admin.utils import get_model_from_relation
+except ImportError:
+    from django.contrib.admin.util import get_model_from_relation
+
 from django.db import models
 from django.db.models import FieldDoesNotExist
 try:

--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -8,6 +8,7 @@ https://github.com/zmathew/django-linguo
 import itertools
 
 import django
+from django.contrib.admin.utils import get_model_from_relation
 from django.db import models
 from django.db.models import FieldDoesNotExist
 try:
@@ -142,8 +143,9 @@ def get_fields_to_translatable_models(model):
                 # In that case the 'related_model' attribute is set to None
                 # so it is necessary to check for this value before trying to
                 # get translatable fields.
-                if get_translatable_fields_for_model(f.related_model) is not None:
-                    results.append((f.name, f.related_model))
+                related_model = get_model_from_relation(f)
+                if get_translatable_fields_for_model(related_model) is not None:
+                    results.append((f.name, related_model))
     else:
         for field_name in model._meta.get_all_field_names():
             field_object, modelclass, direct, m2m = model._meta.get_field_by_name(field_name)


### PR DESCRIPTION
This replaces #399, to fix issue with django < 1.7 and i dropped my fork repo by mistake :(

`related_model` is a cached property, that contains a string instead of the model eg. when overriding the default `User` model. The patch uses `django.contrib.admin.utils.get_model_from_relation` instead to get the model.

This should also fix #361