### PR TITLE
Fix M2M and inherited managers

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -351,3 +351,61 @@ class MultitableConflictModelA(models.Model):
 
 class MultitableConflictModelB(MultitableConflictModelA):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
+
+
+# ######### Complex M2M with abstract classes and custom managers
+
+class CustomQuerySetX(models.query.QuerySet):
+    pass
+
+
+class CustomManagerX(models.Manager):
+    def get_queryset(self):
+        return CustomQuerySetX(self.model, using=self._db)
+    get_query_set = get_queryset
+
+
+class AbstractBaseModelX(models.Model):
+    name = models.CharField(max_length=255)
+    objects = CustomManagerX()
+
+    class Meta:
+        abstract = True
+
+
+class AbstractModelX(AbstractBaseModelX):
+    class Meta:
+        abstract = True
+
+
+class ModelX(AbstractModelX):
+    pass
+
+
+class AbstractModelXY(models.Model):
+    model_x = models.ForeignKey('ModelX')
+    model_y = models.ForeignKey('ModelY')
+
+    class Meta:
+        abstract = True
+
+
+class ModelXY(AbstractModelXY):
+    pass
+
+
+class CustomManagerY(models.Manager):
+    pass
+
+
+class AbstractModelY(models.Model):
+    title = models.CharField(max_length=255)
+    xs = models.ManyToManyField('ModelX', through='ModelXY')
+    objects = CustomManagerY()
+
+    class Meta:
+        abstract = True
+
+
+class ModelY(AbstractModelY):
+    pass

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -10,7 +10,7 @@ from modeltranslation.tests.models import (
     RichText, RichTextPage, MultitableModelA, MultitableModelB, MultitableModelC, ManagerTestModel,
     CustomManagerTestModel, CustomManager2TestModel, GroupFieldsetsModel, NameModel,
     ThirdPartyRegisteredModel, ProxyTestModel, UniqueNullableModel, OneToOneFieldModel,
-    RequiredModel, DecoratedModel)
+    RequiredModel, DecoratedModel, ModelX, ModelY)
 
 
 class TestTranslationOptions(TranslationOptions):
@@ -205,6 +205,18 @@ translator.register(RequiredModel, RequiredTranslationOptions)
 @register(DecoratedModel)
 class DecoratedTranslationOptions(TranslationOptions):
     fields = ('title',)
+
+
+# ######### Complex M2M with abstract classes and custom managers
+
+class ModelXOptions(TranslationOptions):
+    fields = ('name',)
+translator.register(ModelX, ModelXOptions)
+
+
+class ModelYOptions(TranslationOptions):
+    fields = ('title',)
+translator.register(ModelY, ModelYOptions)
 
 
 # ######### 3-rd party with custom manager


### PR DESCRIPTION
This PR fixes 2 closely related issues:
- #389: models that inherit from an abstract model with a custom manager are not properly patched
- #413: ManyToMany fields defined in abstract models don't work as expected (because of the previous one)

This PR creates:
- models that exhibit the bug in #389 through one of the previously existing tests
- a test that reproduces #413 

Then there's the fix for both bugs :)

Tested with Django 1.10 and 1.11 (Python 3.6), and 1.8 and 1.9 (Python 2.7).