### PR TITLE
Add docstring documentation for utils.unique

### DIFF
--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -95,6 +95,10 @@ def build_css_class(localized_fieldname, prefix=''):
 
 def unique(seq):
     """
+    Returns a generator yielding unique sequence members in order
+    
+    A set by itself will return unique values without any regard for order.
+    
     >>> list(unique([1, 2, 3, 2, 2, 4, 1]))
     [1, 2, 3, 4]
     """


### PR DESCRIPTION
Reading through the code I thought "this function is redundant!, just use `set`!". It appears not to be redundant however, and a short explanation of what it does, and why, should provide clarity when reading the module.