### PR TITLE
Fix Django 2.0 testing, update tox.ini

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -383,8 +383,8 @@ class ModelX(AbstractModelX):
 
 
 class AbstractModelXY(models.Model):
-    model_x = models.ForeignKey('ModelX')
-    model_y = models.ForeignKey('ModelY')
+    model_x = models.ForeignKey('ModelX', on_delete=models.CASCADE)
+    model_y = models.ForeignKey('ModelY', on_delete=models.CASCADE)
 
     class Meta:
         abstract = True

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -121,10 +121,8 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
                    else dummy_context_mgr())
             with mgr:
                 # 0. Render initial migration of auth
-                from django.db import connections, DEFAULT_DB_ALIAS
                 if MIGRATIONS:
-                    call_command('makemigrations', 'auth', verbosity=2, interactive=False,
-                                 database=connections[DEFAULT_DB_ALIAS].alias)
+                    call_command('makemigrations', 'auth', verbosity=2, interactive=False)
 
                 # 1. Reload translation in case USE_I18N was False
                 from django.utils import translation as dj_trans
@@ -165,13 +163,10 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
 
                 # 5. makemigrations (``migrate=False`` in case of south)
                 if MIGRATIONS:
-                    call_command('makemigrations', 'auth', verbosity=2, interactive=False,
-                                 database=connections[DEFAULT_DB_ALIAS].alias)
+                    call_command('makemigrations', 'auth', verbosity=2, interactive=False)
 
                 # 6. Syncdb (``migrate=False`` in case of south)
-                cmd = 'migrate' if MIGRATE_CMD else 'syncdb'
-                call_command(cmd, verbosity=0, migrate=False, interactive=False, run_syncdb=True,
-                             database=connections[DEFAULT_DB_ALIAS].alias, load_initial_data=False)
+                call_command('migrate', verbosity=0, interactive=False, run_syncdb=True)
 
                 # 7. clean migrations
                 if MIGRATIONS:
@@ -2846,7 +2841,7 @@ class TestManager(ModeltranslationTestBase):
         non-nullable fields.
         """
         with auto_populate('required'):
-            call_command('loaddata', 'fixture.json', verbosity=0, commit=False)
+            call_command('loaddata', 'fixture.json', verbosity=0)
             m = models.TestModel.objects.get()
             self.assertEqual(m.title_en, 'foo')
             self.assertEqual(m.title_de, 'foo')
@@ -2857,14 +2852,14 @@ class TestManager(ModeltranslationTestBase):
         """
         Test that the loaddata command takes new option.
         """
-        call_command('loaddata', 'fixture.json', verbosity=0, commit=False, populate='required')
+        call_command('loaddata', 'fixture.json', verbosity=0, populate='required')
         m = models.TestModel.objects.get()
         self.assertEqual(m.title_en, 'foo')
         self.assertEqual(m.title_de, 'foo')
         self.assertEqual(m.text_en, 'bar')
         self.assertEqual(m.text_de, None)
 
-        call_command('loaddata', 'fixture.json', verbosity=0, commit=False, populate='all')
+        call_command('loaddata', 'fixture.json', verbosity=0, populate='all')
         m = models.TestModel.objects.get()
         self.assertEqual(m.title_en, 'foo')
         self.assertEqual(m.title_de, 'foo')
@@ -2873,7 +2868,7 @@ class TestManager(ModeltranslationTestBase):
 
         # Test if option overrides current context
         with auto_populate('all'):
-            call_command('loaddata', 'fixture.json', verbosity=0, commit=False, populate=False)
+            call_command('loaddata', 'fixture.json', verbosity=0, populate=False)
             m = models.TestModel.objects.get()
             self.assertEqual(m.title_en, 'foo')
             self.assertEqual(m.title_de, None)

--- a/runtests.py
+++ b/runtests.py
@@ -2,13 +2,14 @@
 import os
 import sys
 import warnings
+from optparse import OptionParser
 
 import django
 from django.conf import settings
 from django.core.management import call_command
 
 
-def runtests():
+def runtests(test_path='modeltranslation'):
     if not settings.configured:
         # Choose database for settings
         DATABASES = {
@@ -49,10 +50,13 @@ def runtests():
     django.setup()
     warnings.simplefilter('always', DeprecationWarning)
     failures = call_command(
-        'test', 'modeltranslation', interactive=False, failfast=False, verbosity=2)
+        'test', test_path, interactive=False, failfast=False, verbosity=2)
 
     sys.exit(bool(failures))
 
 
 if __name__ == '__main__':
-    runtests()
+    parser = OptionParser()
+
+    (options, args) = parser.parse_args()
+    runtests(*args)

--- a/tox.ini
+++ b/tox.ini
@@ -5,108 +5,20 @@ exclude = .tox,docs/modeltranslation/conf.py
 [tox]
 distribute = False
 envlist =
-    py36-1.11.X,
-    py35-1.11.X,
-    py34-1.11.X,
-    py27-1.11.X,
-    py35-1.10.X,
-    py34-1.10.X,
-    py27-1.10.X,
-    py35-1.9.X,
-    py34-1.9.X,
-    py27-1.9.X,
-    py35-1.8.X,
-    py34-1.8.X,
-    py33-1.8.X,
-    py27-1.8.X,
+    py{27,34,35,36}-1.11.X,
+    py{34,35,36}-2.0.X,
 
 [testenv]
 downloadcache = {toxworkdir}/_download/
 commands =
     django-admin.py --version
     {envpython} runtests.py
-
-
-[testenv:py36-1.11.X]
-basepython = python3.6
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
 deps =
-    Django>=1.11,<1.12
-    Pillow
-
-[testenv:py35-1.11.X]
-basepython = python3.5
-deps =
-    Django>=1.11,<1.12
-    Pillow
-
-[testenv:py34-1.11.X]
-basepython = python3.4
-deps =
-    Django>=1.11,<1.12
-    Pillow
-
-[testenv:py27-1.11.X]
-basepython = python2.7
-deps =
-    Django>=1.11,<1.12
-    Pillow
-
-[testenv:py35-1.10.X]
-basepython = python3.5
-deps =
-    Django>=1.10,<1.11
-    Pillow
-
-[testenv:py34-1.10.X]
-basepython = python3.4
-deps =
-    Django>=1.10,<1.11
-    Pillow
-
-[testenv:py27-1.10.X]
-basepython = python2.7
-deps =
-    Django>=1.10,<1.11
-    Pillow
-
-[testenv:py35-1.9.X]
-basepython = python3.5
-deps =
-    Django>=1.9,<1.10
-    Pillow
-
-[testenv:py34-1.9.X]
-basepython = python3.4
-deps =
-    Django>=1.9,<1.10
-    Pillow
-
-[testenv:py27-1.9.X]
-basepython = python2.7
-deps =
-    Django>=1.9,<1.10
-    Pillow
-
-[testenv:py35-1.8.X]
-basepython = python3.5
-deps =
-    Django>=1.8,<1.9
-    Pillow
-
-[testenv:py34-1.8.X]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.9
-    Pillow
-
-[testenv:py33-1.8.X]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.9
-    Pillow
-
-[testenv:py27-1.8.X]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.9
+    1.11.X: Django==1.11.*
+    2.0.X: Django==2.0.*
     Pillow


### PR DESCRIPTION
- Fix testing in Django 2.0
- Remove old parameters to the commands (Django 2.0 forbids unknown `call_command` parameters)
- Update and simplify `tox.ini`