### PR TITLE
Make tests work when django files are not writable

### DIFF
--- a/modeltranslation/tests/settings.py
+++ b/modeltranslation/tests/settings.py
@@ -2,7 +2,6 @@
 """
 Settings overrided for test time
 """
-import django
 from django.conf import settings
 
 
@@ -24,8 +23,6 @@ MODELTRANSLATION_FALLBACK_LANGUAGES = ()
 
 ROOT_URLCONF = 'modeltranslation.tests.urls'
 
-if django.VERSION < (1, 11):
-    # TODO: Check what this was about
-    MIGRATION_MODULES = {'auth': 'modeltranslation.tests.auth_migrations'}
-else:
-    MIGRATION_MODULES = {}
+# Store auth migrations in our own tree so that tests do not fail
+# when the files of the django module are not writable for us
+MIGRATION_MODULES = {'auth': 'modeltranslation.tests.auth_migrations'}


### PR DESCRIPTION
Running tests as a normal users when the django module is installed system-wide (and it files are thus owned by root) results in failures:
```
======================================================================
ERROR: setUpClass (modeltranslation.tests.tests.FallbackTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/django/test/testcases.py", line 1025, in setUpClass
    super(TestCase, cls).setUpClass()
  File "/home/rhertzog/deb/pkg/django-modeltranslation/modeltranslation/tests/tests.py", line 127, in setUpClass
    database=connections[DEFAULT_DB_ALIAS].alias)
  File "/usr/lib/python2.7/dist-packages/django/core/management/__init__.py", line 131, in call_command
    return command.execute(*args, **defaults)
  File "/usr/lib/python2.7/dist-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/usr/lib/python2.7/dist-packages/django/core/management/commands/makemigrations.py", line 193, in handle
    self.write_migration_files(changes)
  File "/usr/lib/python2.7/dist-packages/django/core/management/commands/makemigrations.py", line 232, in write_migration_files
    with io.open(writer.path, "w", encoding='utf-8') as fh:
IOError: [Errno 13] Permission denied: '/usr/lib/python2.7/dist-packages/django/contrib/auth/migrations/0009_auto_20180221_1603.py'
```

The solution is simply to let Django know that we want to use a local directory to store migrations with the MIGRATION_MODULES setting. I don't know why you enabled it only for Django < 1.11 in modeltranslation/tests/settings.py as I really need this setting even with Django 1.11 here.

(This is a followup to #377 which was my initial submission and now when I upgraded to 0.12.2 I got bitten by the same problem again)