### PR TITLE
Fix Django 2 related object descriptor cache

### DIFF
--- a/modeltranslation/fields.py
+++ b/modeltranslation/fields.py
@@ -404,6 +404,15 @@ class LanguageCacheSingleObjectDescriptor(object):
 
     @property
     def cache_name(self):
+        """
+        Used in django 1.x
+        """
         lang = get_language()
         cache = build_localized_fieldname(self.accessor, lang)
         return "_%s_cache" % cache
+
+    def get_cache_name(self):
+        """
+        Used in django 2.x
+        """
+        return build_localized_fieldname(self.accessor, get_language())

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from functools import partial
+
 from django import VERSION
 from django.utils.six import with_metaclass
 from django.core.exceptions import ImproperlyConfigured
@@ -428,6 +430,13 @@ def patch_related_object_descriptor_caching(ro_descriptor):
     """
     class NewSingleObjectDescriptor(LanguageCacheSingleObjectDescriptor, ro_descriptor.__class__):
         pass
+
+    if VERSION[0] == 2:
+        ro_descriptor.related.get_cache_name = partial(
+            NewSingleObjectDescriptor.get_cache_name,
+            ro_descriptor,
+        )
+
     ro_descriptor.accessor = ro_descriptor.related.get_accessor_name()
     ro_descriptor.__class__ = NewSingleObjectDescriptor
 


### PR DESCRIPTION
Closes #457
It's a dirty monkey patching, but so far I do not see a faster solution.