### PR TITLE
Don't add MultilingualManager on inherited models

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from django import VERSION
+from django.conf import settings
 from django.core import validators
 from django.db import models
 from django.utils import six
@@ -409,3 +411,12 @@ class AbstractModelY(models.Model):
 
 class ModelY(AbstractModelY):
     pass
+
+# Non-abstract base models whos Manager is not allowed to be overwritten
+
+
+if VERSION >= (1, 8) and "django.contrib.auth" in settings.INSTALLED_APPS:
+    from django.contrib.auth.models import Permission
+
+    class InheritedPermission(Permission):
+        translated_var = models.CharField(max_length=255)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -6,7 +6,7 @@ import os
 import shutil
 
 import django
-from django import forms
+from django import forms, VERSION
 from django.conf import settings as django_settings
 from django.contrib.admin.sites import AdminSite
 from django.core.exceptions import ValidationError, ImproperlyConfigured
@@ -56,7 +56,7 @@ models = translation = None
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 31 + (1 if MIGRATIONS else 0)
+TEST_MODELS = 32 + (1 if MIGRATIONS else 0)
 
 
 class reload_override_settings(override_settings):
@@ -3174,3 +3174,19 @@ class M2MTest(ModeltranslationTestBase):
             # Again: 1 X named "bar" (but through the M2M field)
             x_bar = y.xs.filter(name="bar")
             self.assertIn(x2, x_bar)
+
+
+class InheritedPermissionTestCase(ModeltranslationTestBase):
+    def test_managers_failure(self):
+        """This fails with 0.13b."""
+        if VERSION < (1, 8):
+            return
+        if "django.contrib.auth" not in django_settings.INSTALLED_APPS:
+            return
+        from django.contrib.auth.models import Permission, User
+        # This happens at initialization time, depending on the models
+        # initialized.
+        Permission._meta._expire_cache()
+        User.objects.create(username='123', is_active=True)
+        x = User.objects.first()
+        x.has_perm('test_perm')

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -223,7 +223,13 @@ translator.register(ModelY, ModelYOptions)
 
 if VERSION >= (1, 8) and "django.contrib.auth" in settings.INSTALLED_APPS:
     from django.contrib.auth.models import Group
+    from .models import InheritedPermission
 
     @register(Group)
     class GroupTranslationOptions(TranslationOptions):
         fields = ('name',)
+
+    @register(InheritedPermission)
+    class InheritedPermissionOptions(TranslationOptions):
+        fields = ('translated_var',)
+        required_languages = [x[0] for x in settings.LANGUAGES]

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -227,9 +227,6 @@ def add_manager(model):
             for manager in base._meta.local_managers:
                 if manager.name in seen:
                     continue
-                if manager.model is not model and not manager.model._meta.abstract:
-                    # Don't add managers to non-abstract inherited base Models
-                    continue
                 managers.append(manager)
                 seen.add(manager.name)
 

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -227,6 +227,8 @@ def add_manager(model):
             for manager in base._meta.local_managers:
                 if manager.name in seen:
                     continue
+                if manager.model is not model:
+                    continue
                 managers.append(manager)
                 seen.add(manager.name)
 

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -227,7 +227,8 @@ def add_manager(model):
             for manager in base._meta.local_managers:
                 if manager.name in seen:
                     continue
-                if manager.model is not model:
+                if manager.model is not model and not manager.model._meta.abstract:
+                    # Don't add managers to non-abstract inherited base Models
                     continue
                 managers.append(manager)
                 seen.add(manager.name)


### PR DESCRIPTION
When using inherited models, modeltranslation adds the manager to the model that is inherited into the new model. I use a modeltranslated `django.core.auth.models.Permission` inherited into my translated `ticketshop.account.models.Permission`. This fixes the occurring errors when `has_perm()` on `User` blows up with modeltranslation complaining about the original `Permission` model not being translated.