### PR TITLE
fix: copy form defined widget attrs

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -66,6 +66,12 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         else:
             orig_formfield = self.formfield_for_dbfield(orig_field, **kwargs)
             field.widget = deepcopy(orig_formfield.widget)
+            # if any widget attrs are defined on the form they should be copied
+            try:
+                field.widget = deepcopy(self.form._meta.widgets[orig_field.name])
+            except (AttributeError, TypeError, KeyError):
+                pass
+            # field.widget = deepcopy(orig_formfield.widget)
             if orig_field.name in self.both_empty_values_fields:
                 from modeltranslation.forms import NullableField, NullCharField
                 form_class = field.__class__

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2200,6 +2200,34 @@ class TranslationAdminTest(ModeltranslationTestBase):
         self.assertEqual(
             tuple(ma.get_form(request, self.test_obj).base_fields.keys()), tuple(fields))
 
+    def test_model_form_widgets(self):
+        class TestModelForm(forms.ModelForm):
+            class Meta:
+                model = models.TestModel
+                fields = ['text',]
+                widgets = {
+                    'text': forms.Textarea(attrs={'myprop': 'myval'}),
+                }
+
+        class TestModelAdmin(admin.TranslationAdmin):
+            form = TestModelForm
+
+        ma = TestModelAdmin(models.TestModel, self.site)
+        fields = ['text_de', 'text_en']
+        self.assertEqual(
+            tuple(ma.get_form(request).base_fields.keys()), tuple(fields))
+        self.assertEqual(
+            tuple(ma.get_form(request, self.test_obj).base_fields.keys()), tuple(fields))
+
+        mf = TestModelForm(instance=self.test_obj)
+        for field in fields:
+            self.assertIn('myprop',
+                ma.get_form(request).base_fields.get(field).widget.attrs.keys()
+            )
+            self.assertIn('myval',
+                ma.get_form(request, self.test_obj).base_fields.get(field).widget.attrs.values()
+            )
+
     def test_inline_fieldsets(self):
         class DataInline(admin.TranslationStackedInline):
             model = models.DataModel

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2204,7 +2204,7 @@ class TranslationAdminTest(ModeltranslationTestBase):
         class TestModelForm(forms.ModelForm):
             class Meta:
                 model = models.TestModel
-                fields = ['text',]
+                fields = ['text', ]
                 widgets = {
                     'text': forms.Textarea(attrs={'myprop': 'myval'}),
                 }
@@ -2219,12 +2219,13 @@ class TranslationAdminTest(ModeltranslationTestBase):
         self.assertEqual(
             tuple(ma.get_form(request, self.test_obj).base_fields.keys()), tuple(fields))
 
-        mf = TestModelForm(instance=self.test_obj)
         for field in fields:
-            self.assertIn('myprop',
+            self.assertIn(
+                'myprop',
                 ma.get_form(request).base_fields.get(field).widget.attrs.keys()
             )
-            self.assertIn('myval',
+            self.assertIn(
+                'myval',
                 ma.get_form(request, self.test_obj).base_fields.get(field).widget.attrs.values()
             )
 


### PR DESCRIPTION
Hi, 

I've noticed in my project that custom defined widget attrs are not used on translated fields in Admin.
This might be a naive fix, so if you have anything you would like to add I can try and add in or cover.

I think this problem might also apply for other things that can get defined in meta like:
help_texts dict or error_messages ...