### PR TITLE
Add app_label and model_name arguments to update_translation_fields command

### DIFF
--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -15,10 +15,12 @@ class Command(BaseCommand):
         verbosity = options['verbosity']
         if verbosity > 0:
             self.stdout.write("Using default language: %s" % DEFAULT_LANGUAGE)
+
         models = translator.get_registered_models(abstract=False)
         for model in models:
             if verbosity > 0:
                 self.stdout.write("Updating data of model '%s'" % model)
+
             opts = translator.get_options_for_model(model)
             for field_name in opts.fields.keys():
                 def_lang_fieldname = build_localized_fieldname(field_name, DEFAULT_LANGUAGE)
@@ -30,4 +32,5 @@ class Command(BaseCommand):
                     q |= Q(**{def_lang_fieldname: ""})
 
                 model._default_manager.filter(q).rewrite(False).update(
-                    **{def_lang_fieldname: F(field_name)})
+                    **{def_lang_fieldname: F(field_name)}
+                )

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
             ' values from original fields (in all translated models).')
 
     def handle(self, *args, **options):
-        verbosity = int(options['verbosity'])
+        verbosity = options['verbosity']
         if verbosity > 0:
             self.stdout.write("Using default language: %s" % DEFAULT_LANGUAGE)
         models = translator.get_registered_models(abstract=False)

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -14,11 +14,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         verbosity = int(options['verbosity'])
         if verbosity > 0:
-            self.stdout.write("Using default language: %s\n" % DEFAULT_LANGUAGE)
+            self.stdout.write("Using default language: %s" % DEFAULT_LANGUAGE)
         models = translator.get_registered_models(abstract=False)
         for model in models:
             if verbosity > 0:
-                self.stdout.write("Updating data of model '%s'\n" % model)
+                self.stdout.write("Updating data of model '%s'" % model)
             opts = translator.get_options_for_model(model)
             for field_name in opts.fields.keys():
                 def_lang_fieldname = build_localized_fieldname(field_name, DEFAULT_LANGUAGE)

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -26,7 +26,9 @@ class Command(BaseCommand):
         if verbosity > 0:
             self.stdout.write("Using default language: %s" % DEFAULT_LANGUAGE)
 
+        # get all models excluding proxy- and not managed models
         models = translator.get_registered_models(abstract=False)
+        models = [m for m in models if not m._meta.proxy and m._meta.managed]
 
         # optionally filter by given app_label
         app_label = options['app_label']

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -11,12 +11,40 @@ class Command(BaseCommand):
     help = ('Updates empty values of default translation fields using'
             ' values from original fields (in all translated models).')
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'app_label', nargs='?',
+            help='App label of an application to update empty values.',
+        )
+        parser.add_argument(
+            'model_name', nargs='?',
+            help='Model name to update empty values of only this model.',
+        )
+
     def handle(self, *args, **options):
         verbosity = options['verbosity']
         if verbosity > 0:
             self.stdout.write("Using default language: %s" % DEFAULT_LANGUAGE)
 
         models = translator.get_registered_models(abstract=False)
+
+        # optionally filter by given app_label
+        app_label = options['app_label']
+        if app_label:
+            models = [m for m in models if m._meta.app_label == app_label]
+
+        # optionally filter by given model_name
+        model_name = options['model_name']
+        if model_name:
+            model_name = model_name.lower()
+            models = [m for m in models if m._meta.model_name == model_name]
+
+        if verbosity > 0:
+            self.stdout.write("Working on models: %s" % ', '.join([
+                "{app_label}.{object_name}".format(**m._meta.__dict__)
+                for m in models
+            ]))
+
         for model in models:
             if verbosity > 0:
                 self.stdout.write("Updating data of model '%s'" % model)


### PR DESCRIPTION
This updates the `update_translation_fields` command to satisfy a requirement I had in a project with proxy-models and especially *database views* using [django-pgviews](https://github.com/mypebble/django-pgviews). 

- While the command works just fine with proxy-models, updating fields on the proxy-model, that were already updated using the concrete model is redundant.
- When using pgviews, model classes are written with the `Meta` option `managed = False`. The model's fields are constructed (or reflected) to match the database view and can be used like a normal model incl. registering with `modeltranslation`, it is just not used with migrations. Obviously a database view is not writable, therefore the command fails; it should only operate on the tables/models the view is based on.

This changes the command so that proxy models (`proxy = True`) and models not managed by Django (`managed = False`) are generally ignored. Furthermore it adds two optional, positional arguments to update only fields in models of a specific app or even just a single model.