### PR TITLE
Use get_fields hook

### DIFF
--- a/docs/modeltranslation/admin.rst
+++ b/docs/modeltranslation/admin.rst
@@ -38,11 +38,11 @@ method does the following:
    translation field required instead.
 
 
-get_form/get_fieldsets/_declared_fieldsets
+get_form/get_fieldsets
 ******************************************
 
-In addition the ``TranslationBaseModelAdmin`` class overrides ``get_form``,
-``get_fieldsets`` and ``_declared_fieldsets`` to make the options ``fields``,
+In addition the ``TranslationBaseModelAdmin`` class overrides ``get_form`` and
+``get_fieldsets`` to make the options ``fields``,
 ``exclude`` and ``fieldsets`` work in a transparent way. It basically does:
 
 1. Removes the original field from every admin form by adding it to


### PR DESCRIPTION
TranslationBaseModelAdmin was using only field names declared in "fields" property ignoring the fields returned by "get_fields" method.

This issue was reported here https://github.com/deschler/django-modeltranslation/issues/473