### PR TITLE
Fixed 'formfield_for_dbfield' method signature. See #510

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -35,12 +35,14 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
             return [(None, {'fields': self.replace_orig_field(self.get_fields(request, obj))})]
         return None
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
-        field = super(TranslationBaseModelAdmin, self).formfield_for_dbfield(db_field, **kwargs)
-        self.patch_translation_field(db_field, field, **kwargs)
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        field = super(TranslationBaseModelAdmin, self).formfield_for_dbfield(
+            db_field, request, **kwargs
+        )
+        self.patch_translation_field(db_field, field, request, **kwargs)
         return field
 
-    def patch_translation_field(self, db_field, field, **kwargs):
+    def patch_translation_field(self, db_field, field, request, **kwargs):
         if db_field.name in self.trans_opts.fields:
             if field.required:
                 field.required = False
@@ -54,7 +56,9 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         except AttributeError:
             pass
         else:
-            orig_formfield = self.formfield_for_dbfield(orig_field, **kwargs)
+            orig_formfield = self.formfield_for_dbfield(
+                orig_field, request, **kwargs
+            )
             field.widget = deepcopy(orig_formfield.widget)
             # if any widget attrs are defined on the form they should be copied
             try:

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -15,7 +15,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.management import call_command
 from django.db import IntegrityError
-from django.db.models import Q, F, Count
+from django.db.models import Q, F, Count, TextField
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils import six
@@ -2164,6 +2164,34 @@ class TranslationAdminTest(ModeltranslationTestBase):
 
         class TestModelAdmin(admin.TranslationAdmin):
             form = TestModelForm
+
+        ma = TestModelAdmin(models.TestModel, self.site)
+        fields = ['text_de', 'text_en']
+        self.assertEqual(
+            tuple(ma.get_form(request).base_fields.keys()), tuple(fields))
+        self.assertEqual(
+            tuple(ma.get_form(request, self.test_obj).base_fields.keys()), tuple(fields))
+
+        for field in fields:
+            self.assertIn(
+                'myprop',
+                ma.get_form(request).base_fields.get(field).widget.attrs.keys()
+            )
+            self.assertIn(
+                'myval',
+                ma.get_form(request, self.test_obj).base_fields.get(field).widget.attrs.values()
+            )
+
+    def test_widget_ordering_via_formfield_for_dbfield(self):
+        class TestModelAdmin(admin.TranslationAdmin):
+            fields = ['text']
+            def formfield_for_dbfield(self, db_field, request, **kwargs):
+                if isinstance(db_field, TextField):
+                    kwargs["widget"] = forms.Textarea(attrs={'myprop': 'myval'})
+                    return db_field.formfield(**kwargs)
+                return super(TestModelAdmin, self).formfield_for_dbfield(
+                    db_field, request, **kwargs
+                )
 
         ma = TestModelAdmin(models.TestModel, self.site)
         fields = ['text_de', 'text_en']

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2185,6 +2185,7 @@ class TranslationAdminTest(ModeltranslationTestBase):
     def test_widget_ordering_via_formfield_for_dbfield(self):
         class TestModelAdmin(admin.TranslationAdmin):
             fields = ['text']
+
             def formfield_for_dbfield(self, db_field, request, **kwargs):
                 if isinstance(db_field, TextField):
                     kwargs["widget"] = forms.Textarea(attrs={'myprop': 'myval'})


### PR DESCRIPTION
It's a fix for `TypeError: formfield_for_dbfield() takes 2 positional arguments but 3 were given` issue when you try to override `formfield_for_dbfield` method in `TranslationAdmin`. See #510.

