### PR TITLE
Fix for issue #523

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -313,6 +313,27 @@ class CustomManager2TestModel(models.Model):
     objects = CustomManager2()
 
 
+class CustomManagerAbstract(models.Manager):
+    def to_translate(self):
+        return self.get_queryset().filter(needs_translation=True)
+
+
+class CustomManagerBaseModel(models.Model):
+    needs_translation = models.BooleanField(default=False)
+
+    objects = models.Manager()
+    translations = CustomManagerAbstract()
+
+    class Meta:
+        abstract = True
+
+
+class CustomAbstractManagerTestModel(CustomManagerBaseModel):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
+
+    objects = CustomManager2()
+
+
 # ######### Required fields testing
 
 class RequiredModel(models.Model):

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -314,24 +314,27 @@ class CustomManager2TestModel(models.Model):
 
 
 class CustomManagerAbstract(models.Manager):
-    def to_translate(self):
-        return self.get_queryset().filter(needs_translation=True)
+    pass
 
 
 class CustomManagerBaseModel(models.Model):
     needs_translation = models.BooleanField(default=False)
 
-    objects = models.Manager()
+    objects = models.Manager()  # ensures objects is the default manager
     translations = CustomManagerAbstract()
 
     class Meta:
         abstract = True
 
 
-class CustomAbstractManagerTestModel(CustomManagerBaseModel):
+class CustomManagerChildTestModel(CustomManagerBaseModel):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
 
     objects = CustomManager2()
+
+
+class PlainChildTestModel(CustomManagerBaseModel):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
 
 
 # ######### Required fields testing

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -25,6 +25,7 @@ from django.apps import apps as django_apps
 
 from modeltranslation import admin, settings as mt_settings, translator
 from modeltranslation.forms import TranslationModelForm
+from modeltranslation.manager import MultilingualManager
 from modeltranslation.models import autodiscover
 from modeltranslation.tests.test_settings import TEST_SETTINGS
 from modeltranslation.utils import (build_css_class, build_localized_fieldname,
@@ -39,7 +40,7 @@ models = translation = None
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 31 + (1 if MIGRATIONS else 0)
+TEST_MODELS = 32 + (1 if MIGRATIONS else 0)
 
 
 class reload_override_settings(override_settings):
@@ -2731,8 +2732,11 @@ class TestManager(ModeltranslationTestBase):
         self.assertTrue(isinstance(manager, MultilingualManager))
 
     def test_default_manager_for_inherited_models(self):
-        manager = models.CustomAbstractManagerTestModel()._meta.default_manager
+        """Test if default manager is still set from local managers"""
+        manager = models.CustomAbstractManagerTestModel._meta.default_manager
         self.assertEqual('objects', manager.name)
+        self.assertTrue(isinstance(manager, MultilingualManager))
+        self.assertTrue(isinstance(models.CustomAbstractManagerTestModel.translations, MultilingualManager))
 
     def test_custom_manager2(self):
         """Test if user-defined queryset is still working"""

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -40,7 +40,7 @@ models = translation = None
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 32 + (1 if MIGRATIONS else 0)
+TEST_MODELS = 33 + (1 if MIGRATIONS else 0)
 
 
 class reload_override_settings(override_settings):
@@ -2731,12 +2731,17 @@ class TestManager(ModeltranslationTestBase):
         manager = models.CustomManagerTestModel.another_mgr_name
         self.assertTrue(isinstance(manager, MultilingualManager))
 
-    def test_default_manager_for_inherited_models(self):
+    def test_default_manager_for_inherited_models_with_custom_manager(self):
         """Test if default manager is still set from local managers"""
-        manager = models.CustomAbstractManagerTestModel._meta.default_manager
+        manager = models.CustomManagerChildTestModel._meta.default_manager
         self.assertEqual('objects', manager.name)
         self.assertTrue(isinstance(manager, MultilingualManager))
-        self.assertTrue(isinstance(models.CustomAbstractManagerTestModel.translations, MultilingualManager))
+        self.assertTrue(isinstance(models.CustomManagerChildTestModel.translations, MultilingualManager))
+
+    def test_default_manager_for_inherited_models(self):
+        manager = models.PlainChildTestModel._meta.default_manager
+        self.assertEqual('objects', manager.name)
+        self.assertTrue(isinstance(models.PlainChildTestModel.translations, MultilingualManager))
 
     def test_custom_manager2(self):
         """Test if user-defined queryset is still working"""

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2736,7 +2736,9 @@ class TestManager(ModeltranslationTestBase):
         manager = models.CustomManagerChildTestModel._meta.default_manager
         self.assertEqual('objects', manager.name)
         self.assertTrue(isinstance(manager, MultilingualManager))
-        self.assertTrue(isinstance(models.CustomManagerChildTestModel.translations, MultilingualManager))
+        self.assertTrue(isinstance(
+            models.CustomManagerChildTestModel.translations,
+            MultilingualManager))
 
     def test_default_manager_for_inherited_models(self):
         manager = models.PlainChildTestModel._meta.default_manager

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2730,6 +2730,10 @@ class TestManager(ModeltranslationTestBase):
         manager = models.CustomManagerTestModel.another_mgr_name
         self.assertTrue(isinstance(manager, MultilingualManager))
 
+    def test_default_manager_for_inherited_models(self):
+        manager = models.CustomAbstractManagerTestModel()._meta.default_manager
+        self.assertEqual('objects', manager.name)
+
     def test_custom_manager2(self):
         """Test if user-defined queryset is still working"""
         from modeltranslation.manager import MultilingualManager, MultilingualQuerySet

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -144,8 +144,6 @@ class CustomManagerTestModelTranslationOptions(TranslationOptions):
     fields = ('title',)
 
 
-
-
 # ######### TranslationOptions field inheritance testing
 
 class FieldInheritanceATranslationOptions(TranslationOptions):

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -137,9 +137,12 @@ class ManagerTestModelTranslationOptions(TranslationOptions):
 @register([
     models.CustomManagerTestModel,
     models.CustomManager2TestModel,
+    models.CustomAbstractManagerTestModel
 ])
 class CustomManagerTestModelTranslationOptions(TranslationOptions):
     fields = ('title',)
+
+
 
 
 # ######### TranslationOptions field inheritance testing

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -137,7 +137,8 @@ class ManagerTestModelTranslationOptions(TranslationOptions):
 @register([
     models.CustomManagerTestModel,
     models.CustomManager2TestModel,
-    models.CustomAbstractManagerTestModel
+    models.CustomManagerChildTestModel,
+    models.PlainChildTestModel
 ])
 class CustomManagerTestModelTranslationOptions(TranslationOptions):
     fields = ('title',)


### PR DESCRIPTION
Make sure model managers added as local managers have their counter reset, so that they don't override the default manager. This fixes issue #523 