### PR TITLE
Fix failing tests when local migrations are used (Fixes: #527).

### DIFF
--- a/modeltranslation/tests/settings.py
+++ b/modeltranslation/tests/settings.py
@@ -2,7 +2,6 @@
 """
 Settings overrided for test time
 """
-import django
 from django.conf import settings
 
 
@@ -24,8 +23,4 @@ MODELTRANSLATION_FALLBACK_LANGUAGES = ()
 
 ROOT_URLCONF = 'modeltranslation.tests.urls'
 
-if django.VERSION < (1, 11):
-    # TODO: Check what this was about
-    MIGRATION_MODULES = {'auth': 'modeltranslation.tests.auth_migrations'}
-else:
-    MIGRATION_MODULES = {}
+MIGRATION_MODULES = {'auth': 'modeltranslation.tests.auth_migrations'}


### PR DESCRIPTION
The following tests issues are adressed in this patch:

- Settings are changed so that local tests.auth_migrations are used
  instead of django.contrib.auth.migrations
- Distributed django.contrib.auth.migrations are copied to
  tests.auth_migrations for tests
- All migrations are deleted from tests.auth_migrations on teardown