### PR TITLE
replace force_text to support django 3

### DIFF
--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 
 import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import get_language as _get_language
 from django.utils.translation import get_language_info
 from django.utils.functional import lazy
@@ -51,7 +51,7 @@ def build_localized_fieldname(field_name, lang):
 def _build_localized_verbose_name(verbose_name, lang):
     if lang == 'id':
         lang = 'ind'
-    return force_text('%s [%s]') % (force_text(verbose_name), lang)
+    return force_str('%s [%s]') % (force_str(verbose_name), lang)
 build_localized_verbose_name = lazy(_build_localized_verbose_name, six.text_type)
 
 


### PR DESCRIPTION
As of Django 3, force_text is deprecated and should be replaced with force_str