### PR TITLE
base_manager shouldnt be the same as default_manager

### DIFF
--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -5,6 +5,9 @@ from django.core import validators
 from django.db import models
 from django.utils.translation import ugettext_lazy
 
+# from modeltranslation.manager import MultilingualManager
+from modeltranslation.manager import MultilingualManager
+
 
 class TestModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)
@@ -100,9 +103,9 @@ class OtherFieldsModel(models.Model):
     boolean = models.BooleanField(default=False)
     nullboolean = models.NullBooleanField()
     csi = models.CommaSeparatedIntegerField(max_length=255)
+    ip = models.IPAddressField(blank=True, null=True)
     float = models.FloatField(blank=True, null=True)
     decimal = models.DecimalField(max_digits=5, decimal_places=2, blank=True, null=True)
-    ip = models.IPAddressField(blank=True, null=True)
     date = models.DateField(blank=True, null=True)
     datetime = models.DateTimeField(blank=True, null=True)
     time = models.TimeField(blank=True, null=True)
@@ -264,6 +267,23 @@ class ThirdPartyRegisteredModel(models.Model):
 
 
 # ######### Manager testing
+class FilteredManager(MultilingualManager):
+    def get_queryset(self):
+        # always return empty queryset
+        return super(FilteredManager, self).get_queryset().filter(pk=None)
+
+
+class FilteredTestModel(models.Model):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    objects = FilteredManager()
+
+
+class ForeignKeyFilteredModel(models.Model):
+    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    test = models.ForeignKey(
+        FilteredTestModel, null=True, related_name="test_fks", on_delete=models.CASCADE,
+    )
+
 
 class ManagerTestModel(models.Model):
     title = models.CharField(ugettext_lazy('title'), max_length=255)

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -58,6 +58,15 @@ class OneToOneFieldModelTranslationOptions(TranslationOptions):
     fields = ('title', 'test', 'optional', 'non',)
 
 
+@register(models.FilteredTestModel)
+class FilteredTestModelTranslationOptions(TranslationOptions):
+    fields = ('title', )
+
+
+@register(models.ForeignKeyFilteredModel)
+class ForeignKeyFilteredModelTranslationOptions(TranslationOptions):
+    fields = ('title', )
+
 # ######### Custom fields testing
 
 @register(models.OtherFieldsModel)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -130,35 +130,8 @@ class MultilingualOptions(options.Options):
 
     @cached_property
     def base_manager(self):
-        """
-        Because base_manager get cached and initialised when no base_manager_name is set.
-        This will overwrites the class used as default manager
-        """
-
-        base_manager_name = self.base_manager_name
-        if not base_manager_name:
-            # Get the first parent's base_manager_name if there's one.
-            for parent in self.model.mro()[1:]:
-                if hasattr(parent, '_meta'):
-                    if parent._base_manager.name != '_base_manager':
-                        base_manager_name = parent._base_manager.name
-                    break
-
-        if base_manager_name:
-            try:
-                return self.managers_map[base_manager_name]
-            except KeyError:
-                raise ValueError(
-                    "%s has no manager named %r" % (
-                        self.object_name,
-                        base_manager_name,
-                    )
-                )
-
-        manager = MultilingualManager()  # this bad boy
-        manager.name = '_base_manager'
-        manager.model = self.model
-        manager.auto_created = True
+        manager = super(MultilingualOptions, self).base_manager
+        manager.__class__ = MultilingualManager
         return manager
 
 


### PR DESCRIPTION
…ty that creates a manager each time it is required. So overwriting didnt work. Now i am far from a metaclass expert and im sure this can be done neater, however this is all the time i have at the moment. Improvements shouldnt be too hard now the issue has a (ugly) fix. Also added a short test, but i am used to pytest, so forgive me for the ugly manager solution. Hope this can help you out.

I am happy to improve on any suggestions made before merging