### PR TITLE
Fix TypeError in admin when all model fields are read-only

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -215,7 +215,7 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         TranslationAdmin and TranslationInlineModelAdmin.
         """
         base_fields = self.replace_orig_field(form.base_fields.keys())
-        fields = base_fields + list(self.get_readonly_fields(request, obj))
+        fields = list(base_fields) + list(self.get_readonly_fields(request, obj))
         return [(None, {'fields': self.replace_orig_field(fields)})]
 
     def get_translation_field_excludes(self, exclude_languages=None):


### PR DESCRIPTION
I get an error in django admin when I set all model fields as read-only, either using `readonly_fields` attribute or `get_readonly_fields` method

```
File "***/site-packages/modeltranslation/admin.py" in _get_fieldsets_post_form_or_formset
  218.         fields = base_fields + list(self.get_readonly_fields(request, obj))

Exception Type: TypeError at /admin/***/change/
Exception Value: unsupported operand type(s) for +: 'odict_keys' and 'list'
```

I am not sure where such error can also occur, but this PR should at least fix this case