### PR TITLE
Update to use `gettext_lazy`

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -297,7 +297,7 @@ class TranslationAdmin(TranslationBaseModelAdmin, admin.ModelAdmin):
                 trans_fieldnames = [f.name for f in sorted(trans_fields, key=lambda x: x.name)]
                 if any(f in trans_fieldnames for f in flattened_fieldsets):
                     # Extract the original field's verbose_name for use as this
-                    # fieldset's label - using ugettext_lazy in your model
+                    # fieldset's label - using gettext_lazy in your model
                     # declaration can make that translatable.
                     label = self.model._meta.get_field(orig_field).verbose_name.capitalize()
                     temp_fieldsets[orig_field] = (label, {

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -3,13 +3,13 @@ import six
 from django.conf import settings
 from django.core import validators
 from django.db import models
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from modeltranslation.manager import MultilingualManager
 
 
 class TestModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     text = models.TextField(blank=True, null=True)
     url = models.URLField(blank=True, null=True)
     email = models.EmailField(blank=True, null=True)
@@ -32,7 +32,7 @@ class ProxyTestModel(TestModel):
 # ######### Fallback values testing
 
 class FallbackModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     text = models.TextField(blank=True, null=True)
     url = models.URLField(blank=True, null=True)
     email = models.EmailField(blank=True, null=True)
@@ -40,7 +40,7 @@ class FallbackModel(models.Model):
 
 
 class FallbackModel2(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     text = models.TextField(blank=True, null=True)
     url = models.URLField(blank=True, null=True)
     email = models.EmailField(blank=True, null=True)
@@ -49,7 +49,7 @@ class FallbackModel2(models.Model):
 # ######### File fields testing
 
 class FileFieldsModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     file = models.FileField(upload_to='modeltranslation_tests', null=True, blank=True)
     file2 = models.FileField(upload_to='modeltranslation_tests')
     image = models.ImageField(upload_to='modeltranslation_tests', null=True, blank=True)
@@ -58,11 +58,11 @@ class FileFieldsModel(models.Model):
 # ######### Foreign Key / OneToOneField testing
 
 class NonTranslated(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
 
 
 class ForeignKeyModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     test = models.ForeignKey(
         TestModel, null=True, related_name="test_fks", on_delete=models.CASCADE,
     )
@@ -79,7 +79,7 @@ class ForeignKeyModel(models.Model):
 
 
 class OneToOneFieldModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     test = models.OneToOneField(
         TestModel, null=True, related_name="test_o2o", on_delete=models.CASCADE,
     )
@@ -158,25 +158,25 @@ class DescriptorModel(models.Model):
 # ######### Multitable inheritance testing
 
 class MultitableModelA(models.Model):
-    titlea = models.CharField(ugettext_lazy('title a'), max_length=255)
+    titlea = models.CharField(gettext_lazy('title a'), max_length=255)
 
 
 class MultitableModelB(MultitableModelA):
-    titleb = models.CharField(ugettext_lazy('title b'), max_length=255)
+    titleb = models.CharField(gettext_lazy('title b'), max_length=255)
 
 
 class MultitableModelC(MultitableModelB):
-    titlec = models.CharField(ugettext_lazy('title c'), max_length=255)
+    titlec = models.CharField(gettext_lazy('title c'), max_length=255)
 
 
 class MultitableModelD(MultitableModelB):
-    titled = models.CharField(ugettext_lazy('title d'), max_length=255)
+    titled = models.CharField(gettext_lazy('title d'), max_length=255)
 
 
 # ######### Abstract inheritance testing
 
 class AbstractModelA(models.Model):
-    titlea = models.CharField(ugettext_lazy('title a'), max_length=255)
+    titlea = models.CharField(gettext_lazy('title a'), max_length=255)
 
     def __init__(self, *args, **kwargs):
         super(AbstractModelA, self).__init__(*args, **kwargs)
@@ -187,7 +187,7 @@ class AbstractModelA(models.Model):
 
 
 class AbstractModelB(AbstractModelA):
-    titleb = models.CharField(ugettext_lazy('title b'), max_length=255)
+    titleb = models.CharField(gettext_lazy('title b'), max_length=255)
 
     def __init__(self, *args, **kwargs):
         super(AbstractModelB, self).__init__(*args, **kwargs)
@@ -273,20 +273,20 @@ class FilteredManager(MultilingualManager):
 
 
 class FilteredTestModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     objects = FilteredManager()
 
 
 class ForeignKeyFilteredModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     test = models.ForeignKey(
         FilteredTestModel, null=True, related_name="test_fks", on_delete=models.CASCADE,
     )
 
 
 class ManagerTestModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
-    visits = models.IntegerField(ugettext_lazy('visits'), default=0)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
+    visits = models.IntegerField(gettext_lazy('visits'), default=0)
     description = models.CharField(max_length=255, null=True)
 
     class Meta:
@@ -310,7 +310,7 @@ class CustomManager(models.Manager):
 
 
 class CustomManagerTestModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     description = models.CharField(max_length=255, null=True, db_column='xyz')
     objects = CustomManager()
 
@@ -328,7 +328,7 @@ class CustomManager2(models.Manager):
 
 
 class CustomManager2TestModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     objects = CustomManager2()
 
 
@@ -347,13 +347,13 @@ class CustomManagerBaseModel(models.Model):
 
 
 class CustomManagerChildTestModel(CustomManagerBaseModel):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
 
     objects = CustomManager2()
 
 
 class PlainChildTestModel(CustomManagerBaseModel):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
 
 
 # ######### Required fields testing
@@ -368,7 +368,7 @@ class RequiredModel(models.Model):
 # ######### Name collision registration testing
 
 class ConflictModel(models.Model):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
     title_de = models.IntegerField()
 
 
@@ -380,7 +380,7 @@ class AbstractConflictModelA(models.Model):
 
 
 class AbstractConflictModelB(AbstractConflictModelA):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
 
 
 class MultitableConflictModelA(models.Model):
@@ -388,7 +388,7 @@ class MultitableConflictModelA(models.Model):
 
 
 class MultitableConflictModelB(MultitableConflictModelA):
-    title = models.CharField(ugettext_lazy('title'), max_length=255)
+    title = models.CharField(gettext_lazy('title'), max_length=255)
 
 
 # ######### Complex M2M with abstract classes and custom managers

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from modeltranslation.translator import translator, register, TranslationOptions
 from modeltranslation.tests import models
@@ -35,7 +35,7 @@ class FallbackModelTranslationOptions(TranslationOptions):
 @register(models.FallbackModel2)
 class FallbackModel2TranslationOptions(TranslationOptions):
     fields = ('title', 'text', 'url', 'email',)
-    fallback_values = {'text': ugettext_lazy('Sorry, translation is not available.')}
+    fallback_values = {'text': gettext_lazy('Sorry, translation is not available.')}
     fallback_undefined = {'title': 'no title'}
 
 

--- a/modeltranslation/widgets.py
+++ b/modeltranslation/widgets.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.forms.widgets import Media, Widget, CheckboxInput
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ClearableWidgetWrapper(Widget):


### PR DESCRIPTION
The use of `ugettext` and variants is deprecated in Django 3.0 and to be removed in Django 4.0.
See more here: https://code.djangoproject.com/ticket/30165