### PR TITLE
docs: Fix simple typo, splitable -> splittable

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -58,7 +58,7 @@ var google, django, gettext;
                  *      id_news-data2-content_type-object_id-0-1-name'
                  */
                 // TODO: We should be able to simplify this, the modeltranslation specific
-                // field classes are already build to be easily splitable, so we could use them
+                // field classes are already build to be easily splittable, so we could use them
                 // to slice off the language code.
                 var idBits = this.id.split('-'),
                     idPrefix = 'id_' + this.origFieldname;

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -66,7 +66,7 @@ def _join_css_class(bits, offset):
 def build_css_class(localized_fieldname, prefix=''):
     """
     Returns a css class based on ``localized_fieldname`` which is easily
-    splitable and capable of regionalized language codes.
+    splittable and capable of regionalized language codes.
 
     Takes an optional ``prefix`` which is prepended to the returned string.
     """


### PR DESCRIPTION
There is a small typo in modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js, modeltranslation/utils.py.

Should read `splittable` rather than `splitable`.

