### PR TITLE
Fix: prevent a new migration from being created each time makemigrations is run

### DIFF
--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -4,6 +4,7 @@ from unittest import skipUnless
 import datetime
 import fnmatch
 import imp
+import io
 import os
 import shutil
 
@@ -164,6 +165,12 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
             # 5. makemigrations (``migrate=False`` in case of south)
             if MIGRATIONS:
                 call_command('makemigrations', 'auth', verbosity=2, interactive=False)
+                # At this point there should not be any migrations to generate
+                out = io.StringIO()
+                call_command('makemigrations', 'auth', verbosity=3,
+                             dry_run=True, interactive=False, stdout=out)
+                assert "No changes detected in app 'auth'\n" == out.getvalue(), \
+                    "Unexpected auth migration:\n %s" % out.getvalue()
 
             # 6. Syncdb (``migrate=False`` in case of south)
             call_command('migrate', verbosity=0, interactive=False, run_syncdb=True)

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -200,6 +200,18 @@ def patch_manager_class(manager):
                     self._constructor_args[1],  # kwargs
                 )
 
+            def __hash__(self):
+                return id(self)
+
+            def __eq__(self, other):
+                if isinstance(other, NewMultilingualManager):
+                    return self._old_module == other._old_module and \
+                        self._old_class == other._old_class
+                if hasattr(other, "__module__") and hasattr(other, "__class__"):
+                    return self._old_module == other.__module__ and \
+                        self._old_class == other.__class__.__name__
+                return False
+
         manager.__class__ = NewMultilingualManager
 
 


### PR DESCRIPTION
When a translated field references a django auth model, a  new migration file is created each time `makemigrations` is run.

This is because modeltranslation generates a new manager `NewMultilingualManager` with a `deconstruct()` method (see [here](https://github.com/deschler/django-modeltranslation/blob/53d2fc9a9ca4d4488ee5a166fa6c5456cacd6f93/modeltranslation/translator.py#L189-L201)) but without a `__eq()__` method.
See [django doc on `deconstruct()`](https://docs.djangoproject.com/en/3.0/topics/migrations/#adding-a-deconstruct-method):
> To prevent a new migration from being created each time `makemigrations` is run, you should also add a `__eq__()` method to the decorated class. This function will be called by Django’s migration framework to detect changes between states.

So, in this PR, `NewMultilingualManager.__eq__()` is implemented in a way that prevent `makemigrations` from seeing it as a new manager.

When adding a `__eq__()` method, the default `__hash__()` method of the object is suppressed (see [here](https://docs.python.org/3.8/reference/datamodel.html#object.__hash__)).
We need `NewMultilingualManager` to be hashable since it's used as one (see [here](https://github.com/deschler/django-modeltranslation/blob/53d2fc9a9ca4d4488ee5a166fa6c5456cacd6f93/modeltranslation/translator.py#L221-L222) for example).
So `__hash__()` is also implemented here with the same implementation as in django [`BaseManager`](https://docs.djangoproject.com/en/2.2/_modules/django/db/models/manager/).
