### PR TITLE
fix custom widget initialization problem

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -60,9 +60,12 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                 orig_field, request, **kwargs
             )
             field.widget = deepcopy(orig_formfield.widget)
+            attrs = field.widget.attrs
             # if any widget attrs are defined on the form they should be copied
             try:
-                field.widget = deepcopy(self.form._meta.widgets[orig_field.name])
+                field.widget = deepcopy(self.form._meta.widgets[orig_field.name])  # this is a class
+                if isinstance(field.widget, type):  # if not initialized
+                    field.widget = field.widget(attrs)  # initialize form widget with attrs
             except (AttributeError, TypeError, KeyError):
                 pass
             # field.widget = deepcopy(orig_formfield.widget)


### PR DESCRIPTION
[From Django docs](https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#overriding-the-default-fields):

```
from django.forms import ModelForm, Textarea
from myapp.models import Author

class AuthorForm(ModelForm):
    class Meta:
        model = Author
        fields = ('name', 'title', 'birth_date')
        widgets = {
            'name': Textarea(attrs={'cols': 80, 'rows': 20}),
        }
```

The widgets dictionary accepts either widget instances (e.g., Textarea(...)) or classes (e.g., Textarea).


---

`django-modeltranslation` assumes it is always the latter approach. This PR fixes the problem with non-initialized widget definitions in `form._meta.widgets`.