### PR TITLE
Adds a language option to the update_translation_fields commands

### DIFF
--- a/docs/modeltranslation/commands.rst
+++ b/docs/modeltranslation/commands.rst
@@ -23,9 +23,13 @@ command:
     $ python manage.py update_translation_fields
 
 Taken the news example used throughout the documentation this command will copy
-the value from the news object's ``title`` field to the default translation
-field ``title_de``. It only does so if the default translation field is empty
+the value from the news object's ``title`` field to the translation
+field ``title_de``. It only does so if the translation field is empty
 otherwise nothing is copied.
+
+On default, only the *default language* will have its translation field populated,
+but you can provide a ``--language`` option to specify any other language listed
+in ``settings.py``.
 
 .. note::
 

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 from django.db.models import F, Q
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
-from modeltranslation.settings import DEFAULT_LANGUAGE
+from modeltranslation.settings import AVAILABLE_LANGUAGES, DEFAULT_LANGUAGE
 from modeltranslation.translator import translator
 from modeltranslation.utils import build_localized_fieldname
 
 
+COMMASPACE = ", "
+
+
 class Command(BaseCommand):
-    help = ('Updates empty values of default translation fields using'
+    help = ('Updates empty values of translation fields using'
             ' values from original fields (in all translated models).')
 
     def add_arguments(self, parser):
@@ -19,6 +22,12 @@ class Command(BaseCommand):
         parser.add_argument(
             'model_name', nargs='?',
             help='Model name to update empty values of only this model.',
+        )
+        parser.add_argument(
+            '--language',
+            action='store',
+            help=('Language translation field the be updated.'
+                  ' Default language field if not provided')
         )
 
     def handle(self, *args, **options):
@@ -41,6 +50,17 @@ class Command(BaseCommand):
             model_name = model_name.lower()
             models = [m for m in models if m._meta.model_name == model_name]
 
+        # optionally defining the translation field language
+        lang = options.get('language') or DEFAULT_LANGUAGE
+        if lang not in AVAILABLE_LANGUAGES:
+            raise CommandError(
+                "Cannot find language '%s'. Options are %s." % (
+                    lang, ", ".join(AVAILABLE_LANGUAGES)
+                )
+            )
+        else:
+            lang = lang.replace('-', '_')
+
         if verbosity > 0:
             self.stdout.write("Working on models: %s" % ', '.join([
                 "{app_label}.{object_name}".format(**m._meta.__dict__)
@@ -53,7 +73,7 @@ class Command(BaseCommand):
 
             opts = translator.get_options_for_model(model)
             for field_name in opts.fields.keys():
-                def_lang_fieldname = build_localized_fieldname(field_name, DEFAULT_LANGUAGE)
+                def_lang_fieldname = build_localized_fieldname(field_name, lang)
 
                 # We'll only update fields which do not have an existing value
                 q = Q(**{def_lang_fieldname: None})


### PR DESCRIPTION
Now, not only the _default language_ will have its translation field populated, but you can provide a ``--language`` option to populate any other language listed on your ``settings.py``.

**My use case was as follows:**

I needed to search an Object by its `name` field, like so:

```python
Object.objects.filter(name__icontains="query")
```

But when someone from Italy tried searching for a translatable object, it would look for the `name_it` field only. If that field was empty, it wouldn't search into the default `name` field as well. The most straightforward solution was to populate all translatable fields regardless of whether they were using the default language or not.

So, if I run:

```shell
python manage.py update_translation_fields --language it
``` 

All the empty `name_it` fields that are empty will contain the value from the `name` field.