### PR TITLE
docs: add optional flags for update_translation_fields command

### DIFF
--- a/docs/modeltranslation/commands.rst
+++ b/docs/modeltranslation/commands.rst
@@ -41,6 +41,16 @@ in ``settings.py``.
 All translated models (as specified in the translation files) from all apps will be
 populated with initial data.
 
+Optionally, an app label and model name may be passed to populate only a subset
+of translated models.
+
+.. code-block:: console
+
+    $ python manage.py update_translation_fields myapp
+
+.. code-block:: console
+
+    $ python manage.py update_translation_fields myapp mymodel
 
 .. _commands-sync_translation_fields:
 


### PR DESCRIPTION
I recently needed to update only a couple of newly added models, and found that the `update_translation_fields` command supports optional arguments to do this, but that those arguments were not mentioned in the documentation.