### PR TITLE
Fix Django 3.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - DJANGO=3.0 DB=sqlite
   - DJANGO=3.0 DB=postgres
   - DJANGO=3.0 DB=mysql
+  - DJANGO=3.2 DB=postgres
+  - DJANGO=3.2 DB=mysql
 before_install:
   - pip install -q flake8
   - PYFLAKES_NODOCTEST=1 flake8 modeltranslation

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -81,6 +81,6 @@ class Command(BaseCommand):
                 if field.empty_strings_allowed:
                     q |= Q(**{def_lang_fieldname: ""})
 
-                model._default_manager.filter(q).rewrite(False).update(
+                model._default_manager.filter(q).rewrite(False).order_by().update(
                     **{def_lang_fieldname: F(field_name)}
                 )


### PR DESCRIPTION
Fixes #582.

Some method signatures were incompatible with Django 3.2:

- `_filter_or_exclude(self, negate, *args, **kwargs)` changed to `_filter_or_exclude(self, negate, args, kwargs)`.
  This change is backwards incompatible, so I had to check `django.VERSION`

- `get_or_create(self, defaults, **kwargs)` gets called by `update_or_create` now with `defaults` as positional argument.
  I just had to add `*args`. This is backwards compatible.

- `values(self, *fields, **expressions)` can be called with keyword arguments.
  I added `**expressions` to `_values` and `values`. This is backwards compatible.