### PR TITLE
fix .latest() ORM method with django 3.2

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -300,7 +300,7 @@ class MultilingualQuerySet(models.query.QuerySet):
     def _rewrite_filter_or_exclude(self, args, kwargs):
         if not self._rewrite:
             return args, kwargs
-        args = map(self._rewrite_q, args)
+        args = tuple(map(self._rewrite_q, args))
         for key, val in list(kwargs.items()):
             new_key = rewrite_lookup_key(self.model, key)
             del kwargs[key]

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2652,9 +2652,10 @@ class TestManager(ModeltranslationTestBase):
 
     def test_latest(self):
         manager = models.ManagerTestModel.objects
-        manager.create(title='more_de', visits_en=1, visits_de=2)
-        manager.create(title='more_en', visits_en=2, visits_de=1)
-        manager.latest("id")
+        instance_1 = manager.create(title='more_de', visits_en=1, visits_de=2)
+        instance_2 = manager.create(title='more_en', visits_en=2, visits_de=1)
+        latest_instance = manager.latest("id")
+        self.assertEqual(latest_instance, instance_2)
 
     def assert_fallback(self, method, expected1, *args, **kwargs):
         transform = kwargs.pop('transform', lambda x: x)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2650,6 +2650,12 @@ class TestManager(ModeltranslationTestBase):
         self.assertEqual(titles_for_en, ('most', 'more_en', 'more_de', 'least'))
         self.assertEqual(titles_for_de, ('most', 'more_de', 'more_en', 'least'))
 
+    def test_latest(self):
+        manager = models.ManagerTestModel.objects
+        manager.create(title='more_de', visits_en=1, visits_de=2)
+        manager.create(title='more_en', visits_en=2, visits_de=1)
+        manager.latest("id")
+
     def assert_fallback(self, method, expected1, *args, **kwargs):
         transform = kwargs.pop('transform', lambda x: x)
         expected2 = kwargs.pop('expected_de', expected1)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ distribute = False
 envlist =
     py{36,37,38}-2.2,
     py{36,37,38}-3.0,
+    py{36,37,38}-3.1,
+    py{36,37,38}-3.2,
 
 [testenv]
 downloadcache = {toxworkdir}/_download/
@@ -21,5 +23,7 @@ basepython =
 deps =
     2.2: Django==2.2.*
     3.0: Django>=3.0a1,<3.1
+    3.1: Django>=3.1,<3.2
+    3.2: Django>=3.2,<4.0
     Pillow
     six

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ exclude = .tox,docs/modeltranslation/conf.py
 [tox]
 distribute = False
 envlist =
-    py{36,37,38}-2.2,
-    py{36,37,38}-3.0,
-    py{36,37,38}-3.1,
-    py{36,37,38}-3.2,
+    py{36,37,38,39}-2.2,
+    py{36,37,38,39}-3.0,
+    py{36,37,38,39}-3.1,
+    py{36,37,38,39}-3.2,
 
 [testenv]
 downloadcache = {toxworkdir}/_download/
@@ -20,6 +20,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 deps =
     2.2: Django==2.2.*
     3.0: Django>=3.0a1,<3.1


### PR DESCRIPTION
fix #591