### PR TITLE
Avoid deprecation warning in Django 3.2+

### DIFF
--- a/modeltranslation/__init__.py
+++ b/modeltranslation/__init__.py
@@ -3,8 +3,12 @@
 Version code adopted from Django development version.
 https://github.com/django/django
 """
+import django
+
 VERSION = (0, 17, 3, 'final', 0)
-default_app_config = 'modeltranslation.apps.ModeltranslationConfig'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'modeltranslation.apps.ModeltranslationConfig'
 
 
 def get_version(version=None):


### PR DESCRIPTION
I followed the same approach as in https://github.com/jazzband/django-debug-toolbar/pull/1467/files