### PR TITLE
fix: Remove default_app_config for Django 3.2+

### DIFF
--- a/modeltranslation/__init__.py
+++ b/modeltranslation/__init__.py
@@ -3,10 +3,12 @@
 Version code adopted from Django development version.
 https://github.com/django/django
 """
+import django
 
 VERSION = (0, 17, 5, 'final', 0)
 
-default_app_config = 'modeltranslation.apps.ModeltranslationConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'modeltranslation.apps.ModeltranslationConfig'
 
 
 def get_version(version=None):


### PR DESCRIPTION
Addresses deprecation warning:

> RemovedInDjango41Warning: 'modeltranslation' defines default_app_config = 'modeltranslation.apps.ModeltranslationConfig'. Django now detects this configuration automatically. You can remove default_app_config.

See: https://docs.djangoproject.com/en/4.0/releases/3.2/#automatic-appconfig-discovery