### PR TITLE
Preserve annotate() fields in queryset

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -415,10 +415,12 @@ class MultilingualQuerySet(models.query.QuerySet):
         if not kwargs.pop('prepare', False):
             return super(MultilingualQuerySet, self)._values(*original, **kwargs)
         new_fields, translation_fields = append_fallback(self.model, original)
+        annotation_keys = set(self.query.annotation_select.keys())
+        new_fields.update(annotation_keys)
         clone = super(MultilingualQuerySet, self)._values(*list(new_fields), **kwargs)
         clone.original_fields = tuple(original)
         clone.translation_fields = translation_fields
-        clone.fields_to_del = new_fields - set(original)
+        clone.fields_to_del = new_fields - annotation_keys - set(original)
         return clone
 
     # This method was not present in django-linguo

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2909,6 +2909,16 @@ class TestManager(ModeltranslationTestBase):
             list(manager.values_list('title', flat=True).annotate(Count('title'))), ['en']
         )
 
+        # custom annotation
+        self.assertEqual(
+            list(manager.filter(id=id1).annotate(custom_id=F('id')).values_list())[0][-1],
+            id1,
+        )
+        self.assertEqual(
+            list(manager.filter(id=id1).annotate(custom_id=F('id')).values())[0].get('custom_id'),
+            id1,
+        )
+
     def test_values_list_annotation(self):
         models.TestModel(title='foo').save()
         models.TestModel(title='foo').save()


### PR DESCRIPTION
`MultilingualQuerysetManager` doesn't respect dynamically selected fields using `annotate()`. This PR adds an availability to preserve annotated fields.
