### PR TITLE
Do not include annotation fields when selects specific fields

### DIFF
--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2919,6 +2919,17 @@ class TestManager(ModeltranslationTestBase):
             id1,
         )
 
+        # custom annotation with fields specified
+        self.assertEqual(
+            list(manager.filter(id=id1).annotate(custom_id=F('id')).values_list('id'))[0],
+            (id1,),
+        )
+        self.assertIsNone(
+            list(manager.filter(id=id1).annotate(custom_id=F('id')).values('id'))[0].get(
+                'custom_id'
+            ),
+        )
+
     def test_values_list_annotation(self):
         models.TestModel(title='foo').save()
         models.TestModel(title='foo').save()


### PR DESCRIPTION
After #633 got merged, I found a non-standard behavior. By default, with using `values()` or `values_list()` with specific fields, the queryset should not include annotated fields.

* `queryset.annotate(foo=bar).values()`: `{'id': 10, 'foo': 'bar'}`  # should include annotated fields
* `queryset.annotate(foo=bar).values('id')`: `{'id': 10}`  # should _**NOT**_ include annotated fields

This PR ensures the Django's default behavior of `values()` and `values_list()` with fields.
