### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/modeltranslation/admin.rst
+++ b/docs/modeltranslation/admin.rst
@@ -47,7 +47,7 @@ In addition the ``TranslationBaseModelAdmin`` class overrides ``get_form`` and
 
 1. Removes the original field from every admin form by adding it to
    ``exclude`` under the hood.
-2. Replaces the - now removed - orginal fields with their corresponding
+2. Replaces the - now removed - original fields with their corresponding
    translation fields.
 
 Taken the ``fieldsets`` option as an example, where the ``title`` field is

--- a/docs/modeltranslation/installation.rst
+++ b/docs/modeltranslation/installation.rst
@@ -272,7 +272,7 @@ Example::
 
 Default: ``()`` (empty tuple)
 
-Modeltranslation uses an autoregister feature similiar to the one in Django's
+Modeltranslation uses an autoregister feature similar to the one in Django's
 admin. The autoregistration process will look for a ``translation.py``
 file in the root directory of each application that is in ``INSTALLED_APPS``.
 
@@ -298,7 +298,7 @@ Example::
     file which was defined through
     ``MODELTRANSLATION_TRANSLATION_REGISTRY = '<PROJECT_MODULE>.translation'``.
 
-    In version 0.4 and 0.5, for backwards compatibiliy, the module defined through this setting was
+    In version 0.4 and 0.5, for backwards compatibility, the module defined through this setting was
     automatically added to ``MODELTRANSLATION_TRANSLATION_FILES``. A
     ``DeprecationWarning`` was issued in this case.
 

--- a/docs/modeltranslation/related_projects.rst
+++ b/docs/modeltranslation/related_projects.rst
@@ -21,7 +21,7 @@ It is not possible to reuse existing models without modifying them.
 
     A much simpler version of the above `django-multilingual`.
 
-It works very similiar to the `django-multilingual` approach.
+It works very similar to the `django-multilingual` approach.
 
 
 `transdb`_

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -204,7 +204,7 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
             # Take the custom ModelForm's Meta.exclude into account only if the
             # ModelAdmin doesn't define its own.
             exclude.extend(self.form._meta.exclude)
-        # If exclude is an empty list we pass None to be consistant with the
+        # If exclude is an empty list we pass None to be consistent with the
         # default on modelform_factory
         exclude = self.replace_orig_field(exclude) or None
         exclude = self._exclude_original_fields(exclude)

--- a/modeltranslation/management/commands/sync_translation_fields.py
+++ b/modeltranslation/management/commands/sync_translation_fields.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
 
     def get_missing_languages(self, field_name, db_table):
         """
-        Gets only missings fields.
+        Gets only missing fields.
         """
         db_table_fields = self.get_table_fields(db_table)
         for lang_code in AVAILABLE_LANGUAGES:

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -482,7 +482,7 @@ class ModelY(AbstractModelY):
     pass
 
 
-# Non-abstract base models whos Manager is not allowed to be overwritten
+# Non-abstract base models whose Manager is not allowed to be overwritten
 
 
 class InheritedPermission(Permission):


### PR DESCRIPTION
There are small typos in:
- docs/modeltranslation/admin.rst
- docs/modeltranslation/installation.rst
- docs/modeltranslation/related_projects.rst
- modeltranslation/admin.py
- modeltranslation/management/commands/sync_translation_fields.py
- modeltranslation/tests/models.py

Fixes:
- Should read `similar` rather than `similiar`.
- Should read `whose` rather than `whos`.
- Should read `original` rather than `orginal`.
- Should read `missing` rather than `missings`.
- Should read `consistent` rather than `consistant`.
- Should read `compatibility` rather than `compatibiliy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md