### PR TITLE
Support UserAdmin add_fieldsets

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -34,8 +34,13 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         # Take custom modelform fields option into account
         if not self.fields and hasattr(self.form, '_meta') and self.form._meta.fields:
             self.fields = self.form._meta.fields
-        if self.fieldsets:
-            return self._patch_fieldsets(self.fieldsets)
+        fieldsets = (
+            self.fieldsets
+            if getattr(self, 'add_fieldsets', None) is None or obj
+            else self.add_fieldsets
+        )
+        if fieldsets:
+            return self._patch_fieldsets(fieldsets)
         elif self.fields:
             return [(None, {'fields': self.replace_orig_field(self.get_fields(request, obj))})]
         return None

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -35,9 +35,9 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         if not self.fields and hasattr(self.form, '_meta') and self.form._meta.fields:
             self.fields = self.form._meta.fields
         fieldsets = (
-            self.fieldsets
-            if getattr(self, 'add_fieldsets', None) is None or obj
-            else self.add_fieldsets
+            self.add_fieldsets
+            if getattr(self, 'add_fieldsets', None) and obj is None
+            else self.fieldsets
         )
         if fieldsets:
             return self._patch_fieldsets(fieldsets)

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -34,6 +34,7 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
         # Take custom modelform fields option into account
         if not self.fields and hasattr(self.form, '_meta') and self.form._meta.fields:
             self.fields = self.form._meta.fields
+        # takes into account non-standard add_fieldsets attribute used by UserAdmin
         fieldsets = (
             self.add_fieldsets
             if getattr(self, 'add_fieldsets', None) and obj is None


### PR DESCRIPTION
This PR adds support for `add_fieldsets` when using UserAdmin. Current behaviour is that this attribute is ignored even though it's supported by Django. (https://docs.djangoproject.com/en/4.1/topics/auth/customizing/#custom-users-and-django-contrib-admin).