### PR TITLE
Fix admin widget for fk fields

### DIFF
--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -95,11 +95,8 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
             ) and isinstance(field.widget, (forms.TextInput, forms.Textarea)):
                 field.widget = ClearableWidgetWrapper(field.widget)
             
-            if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
-                css_classes = field.widget.widget.attrs.get('class', '').split(' ')
-            else:
-                css_classes = field.widget.attrs.get('class', '').split(' ')
-            
+
+            css_classes = self._get_widget_from_field(field).attrs.get('class', '').split(' ')
             css_classes.append('mt')
             # Add localized fieldname css class
             css_classes.append(build_css_class(db_field.name, 'mt-field'))
@@ -122,10 +119,14 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                     if isinstance(field.widget, ClearableWidgetWrapper):
                         field.widget = field.widget.widget
             
-            if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
-                field.widget.widget.attrs['class'] = ' '.join(css_classes)
-            else:
-                field.widget.attrs['class'] = ' '.join(css_classes)
+            self._get_widget_from_field(field).attrs['class'] = ' '.join(css_classes)
+
+    def _get_widget_from_field(self, field):
+        # retrieve "nested" widget in case of related field 
+        if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
+            return field.widget.widget
+        else:
+            return field.widget
 
     def _exclude_original_fields(self, exclude=None):
         if exclude is None:

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -119,7 +119,7 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
             self._get_widget_from_field(field).attrs['class'] = ' '.join(css_classes)
 
     def _get_widget_from_field(self, field):
-        # retrieve "nested" widget in case of related field 
+        # retrieve "nested" widget in case of related field
         if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
             return field.widget.widget
         else:

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -94,8 +94,6 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                 db_field.empty_value == 'both' or orig_field.name in self.both_empty_values_fields
             ) and isinstance(field.widget, (forms.TextInput, forms.Textarea)):
                 field.widget = ClearableWidgetWrapper(field.widget)
-            
-
             css_classes = self._get_widget_from_field(field).attrs.get('class', '').split(' ')
             css_classes.append('mt')
             # Add localized fieldname css class
@@ -118,7 +116,6 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                     # Hide clearable widget for required fields
                     if isinstance(field.widget, ClearableWidgetWrapper):
                         field.widget = field.widget.widget
-            
             self._get_widget_from_field(field).attrs['class'] = ' '.join(css_classes)
 
     def _get_widget_from_field(self, field):

--- a/modeltranslation/admin.py
+++ b/modeltranslation/admin.py
@@ -94,7 +94,12 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                 db_field.empty_value == 'both' or orig_field.name in self.both_empty_values_fields
             ) and isinstance(field.widget, (forms.TextInput, forms.Textarea)):
                 field.widget = ClearableWidgetWrapper(field.widget)
-            css_classes = field.widget.attrs.get('class', '').split(' ')
+            
+            if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
+                css_classes = field.widget.widget.attrs.get('class', '').split(' ')
+            else:
+                css_classes = field.widget.attrs.get('class', '').split(' ')
+            
             css_classes.append('mt')
             # Add localized fieldname css class
             css_classes.append(build_css_class(db_field.name, 'mt-field'))
@@ -116,7 +121,11 @@ class TranslationBaseModelAdmin(BaseModelAdmin):
                     # Hide clearable widget for required fields
                     if isinstance(field.widget, ClearableWidgetWrapper):
                         field.widget = field.widget.widget
-            field.widget.attrs['class'] = ' '.join(css_classes)
+            
+            if isinstance(field.widget, admin.widgets.RelatedFieldWidgetWrapper):
+                field.widget.widget.attrs['class'] = ' '.join(css_classes)
+            else:
+                field.widget.attrs['class'] = ' '.join(css_classes)
 
     def _exclude_original_fields(self, exclude=None):
         if exclude is None:

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2172,6 +2172,23 @@ class TranslationAdminTest(ModeltranslationTestBase):
                 in ma.get_form(request, self.test_obj).base_fields.get(field).widget.attrs.values()
             )
 
+    def test_widget_classes_appended_by_formfield_for_dbfield(self):
+        '''
+        regression test for #660 (https://github.com/deschler/django-modeltranslation/issues/660)
+        '''
+        class ForeignKeyModelModelAdmin(admin.TranslationAdmin):
+            fields = ['test']
+
+        class OneToOneFieldModelAdmin(admin.TranslationAdmin):
+            fields = ['test']
+
+        ma = ForeignKeyModelModelAdmin(models.ForeignKeyModel, self.site)
+        fields = ['test_de', 'test_en']
+        for field in fields:
+            assert {} == ma.get_form(request).base_fields.get(field).widget.attrs
+            assert 'class' in ma.get_form(request).base_fields.get(field).widget.widget.attrs.keys()
+            assert 'mt' in ma.get_form(request).base_fields.get(field).widget.widget.attrs['class']
+
     def test_inline_fieldsets(self):
         class DataInline(admin.TranslationStackedInline):
             model = models.DataModel


### PR DESCRIPTION
This PR resolves #660 by adding a check if the target field is a relation.
The underyling cause has already been explained, but in short:
Related fields are wrapped for the admin representation. For example, a ForeignKey isn't simply a django `SelectWidget`, but a `RelatedFieldWidgetWrapper`. The original code added the `mt` css classes to the wrapper class instead of the real widget, causing the tabbing to fail.

Added makeshift tests, which simply make sure that the `mt` classes are attached to the correct widget.