### PR TITLE
Added support to ManyToManyFields 🧑‍🤝‍🧑

### DIFF
--- a/docs/modeltranslation/caveats.rst
+++ b/docs/modeltranslation/caveats.rst
@@ -66,4 +66,9 @@ Using in combination with ``django-rest-framework``
 -------------------------------------------------
 When creating a new viewset , make sure to override ``get_queryset`` method, using ``queryset`` as a property won't work because it is being evaluated once, before any language was set.
 
+Translating ``ManyToManyField`` fields
+-------------------------------------------------
+Translated ``ManyToManyField`` fields do not support fallbacks. This is because the field descriptor returns a ``Manager`` when accessed. If falbacks were enabled we could find ourselves using the manager of a different language than the current one without realizing it. This can lead to using the ``.set()`` method on the wrong language.
+Due to this behavior the fallbacks on M2M fields have been disabled.
+
 .. _documentation: https://django-audit-log.readthedocs.io/

--- a/modeltranslation/fields.py
+++ b/modeltranslation/fields.py
@@ -1,19 +1,20 @@
-from django import VERSION
-from django import forms
+import copy
+from typing import Iterable
+
+from django import VERSION, forms
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import fields
 
 from modeltranslation import settings as mt_settings
 from modeltranslation.thread_context import fallbacks_enabled
 from modeltranslation.utils import (
-    get_language,
     build_localized_fieldname,
+    build_localized_intermediary_model,
     build_localized_verbose_name,
+    get_language,
     resolution_order,
-    patch_intermediary_model,
 )
 from modeltranslation.widgets import ClearableWidgetWrapper
-
 
 SUPPORTED_FIELDS = (
     fields.CharField,
@@ -85,7 +86,7 @@ def field_factory(baseclass):
     return TranslationFieldSpecific
 
 
-class TranslationField(object):
+class TranslationField:
     """
     The translation field functions as a proxy to the original field which is
     wrapped.
@@ -162,7 +163,6 @@ class TranslationField(object):
         if isinstance(self.translated_field, fields.related.ManyToManyField) and hasattr(
             self.remote_field, "through"
         ):
-            import copy
 
             # Since fields cannot share the same remote_field object:
             self.remote_field = copy.copy(self.remote_field)
@@ -197,15 +197,16 @@ class TranslationField(object):
                     )
 
             # Patch intermediary model with language scope to create correct db table
-            self.remote_field.through = patch_intermediary_model(self, language, translator)
-            self.remote_field.field = self  # Django 1.6
+            self.remote_field.through = build_localized_intermediary_model(
+                self.remote_field.through, language
+            )
+            self.remote_field.field = self
 
             if hasattr(self.remote_field.model._meta, '_related_objects_cache'):
                 del self.remote_field.model._meta._related_objects_cache
 
         # ForeignKey support - rewrite related_name
         elif not NEW_RELATED_API and self.rel and self.related and not self.rel.is_hidden():
-            import copy
 
             current = self.related.get_accessor_name()
             self.rel = copy.copy(self.rel)  # Since fields cannot share the same rel object.
@@ -219,11 +220,10 @@ class TranslationField(object):
                 )
                 self.related_query_name = lambda: loc_related_query_name
             self.rel.related_name = build_localized_fieldname(current, self.language)
-            self.rel.field = self  # Django 1.6
+            self.rel.field = self
             if hasattr(self.rel.to._meta, '_related_objects_cache'):
                 del self.rel.to._meta._related_objects_cache
         elif NEW_RELATED_API and self.remote_field and not self.remote_field.is_hidden():
-            import copy
 
             current = self.remote_field.get_accessor_name()
             # Since fields cannot share the same rel object:
@@ -236,7 +236,7 @@ class TranslationField(object):
                 )
                 self.related_query_name = lambda: loc_related_query_name
             self.remote_field.related_name = build_localized_fieldname(current, self.language)
-            self.remote_field.field = self  # Django 1.6
+            self.remote_field.field = self
             if hasattr(self.remote_field.model._meta, '_related_objects_cache'):
                 del self.remote_field.model._meta._related_objects_cache
 
@@ -336,7 +336,7 @@ class TranslationField(object):
         return cls(*args, **kwargs)
 
 
-class TranslationFieldDescriptor(object):
+class TranslationFieldDescriptor:
     """
     A descriptor used for the original translated field.
     """
@@ -414,13 +414,13 @@ class TranslationFieldDescriptor(object):
             return default
 
 
-class TranslatedRelationIdDescriptor(object):
+class TranslatedRelationIdDescriptor:
     """
     A descriptor used for the original '_id' attribute of a translated
     ForeignKey field.
     """
 
-    def __init__(self, field_name, fallback_languages):
+    def __init__(self, field_name: str, fallback_languages: Iterable[str]):
         self.field_name = field_name  # The name of the original field (excluding '_id')
         self.fallback_languages = fallback_languages
 
@@ -447,7 +447,7 @@ class TranslatedRelationIdDescriptor(object):
         return None
 
 
-class TranslatedManyToManyDescriptor(object):
+class TranslatedManyToManyDescriptor:
     """
     A descriptor used to return correct related manager without language fallbacks.
     """
@@ -468,7 +468,7 @@ class TranslatedManyToManyDescriptor(object):
         setattr(instance, loc_attname, value)
 
 
-class LanguageCacheSingleObjectDescriptor(object):
+class LanguageCacheSingleObjectDescriptor:
     """
     A Mixin for RelatedObjectDescriptors which use current language in cache lookups.
     """

--- a/modeltranslation/models.py
+++ b/modeltranslation/models.py
@@ -40,6 +40,9 @@ def autodiscover():
     for module in TRANSLATION_FILES:
         import_module(module)
 
+    # This executes 'after imports' scheduled operations
+    translator.execute_lazy_operations()
+
     # In debug mode, print a list of registered models and pid to stdout.
     # Note: Differing model order is fine, we don't rely on a particular
     # order, as far as base classes are registered before subclasses.

--- a/modeltranslation/tests/migrations/0001_initial.py
+++ b/modeltranslation/tests/migrations/0001_initial.py
@@ -938,6 +938,335 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='CustomThroughModel',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ManyToManyFieldModel',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                ('title', models.CharField(max_length=255, verbose_name='title')),
+                ('title_de', models.CharField(max_length=255, null=True, verbose_name='title')),
+                ('title_en', models.CharField(max_length=255, null=True, verbose_name='title')),
+                ('self_call_1', models.ManyToManyField(to='tests.manytomanyfieldmodel')),
+                ('self_call_2', models.ManyToManyField(to='tests.manytomanyfieldmodel')),
+                (
+                    'self_call_1_en',
+                    models.ManyToManyField(null=True, to='tests.manytomanyfieldmodel'),
+                ),
+                (
+                    'self_call_1_de',
+                    models.ManyToManyField(null=True, to='tests.manytomanyfieldmodel'),
+                ),
+                (
+                    'self_call_2_en',
+                    models.ManyToManyField(null=True, to='tests.manytomanyfieldmodel'),
+                ),
+                (
+                    'self_call_2_de',
+                    models.ManyToManyField(null=True, to='tests.manytomanyfieldmodel'),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name='RegisteredThroughModel_de',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'rel_1',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='RegisteredThroughModel_de+',
+                        to='tests.manytomanyfieldmodel',
+                    ),
+                ),
+                (
+                    'rel_2',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='RegisteredThroughModel_de+',
+                        to='tests.testmodel',
+                    ),
+                ),
+                ('title', models.CharField(max_length=255, verbose_name='title')),
+                ('title_de', models.CharField(max_length=255, null=True, verbose_name='title')),
+                ('title_en', models.CharField(max_length=255, null=True, verbose_name='title')),
+            ],
+            options={
+                'verbose_name': 'registered through model [de]',
+                'verbose_name_plural': 'registered through models [de]',
+                'db_table': 'tests_registeredthroughmodel_de',
+                'db_tablespace': '',
+                'auto_created': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='RegisteredThroughModel_en',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'rel_1',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='RegisteredThroughModel_en+',
+                        to='tests.manytomanyfieldmodel',
+                    ),
+                ),
+                (
+                    'rel_2',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='RegisteredThroughModel_en+',
+                        to='tests.testmodel',
+                    ),
+                ),
+                ('title', models.CharField(max_length=255, verbose_name='title')),
+                ('title_de', models.CharField(max_length=255, null=True, verbose_name='title')),
+                ('title_en', models.CharField(max_length=255, null=True, verbose_name='title')),
+            ],
+            options={
+                'verbose_name': 'registered through model [en]',
+                'verbose_name_plural': 'registered through models [en]',
+                'db_table': 'tests_registeredthroughmodel_en',
+                'db_tablespace': '',
+                'auto_created': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='RegisteredThroughModel',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                ('title', models.CharField(max_length=255)),
+                ('title_de', models.CharField(max_length=255, null=True)),
+                ('title_en', models.CharField(max_length=255, null=True)),
+                (
+                    'rel_1',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='tests.manytomanyfieldmodel'
+                    ),
+                ),
+                (
+                    'rel_2',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='tests.testmodel'
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='test',
+            field=models.ManyToManyField(related_name='m2m_test_ref', to='tests.testmodel'),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='test_en',
+            field=models.ManyToManyField(
+                null=True, related_name='m2m_test_ref', to='tests.testmodel'
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='test_de',
+            field=models.ManyToManyField(
+                null=True, related_name='m2m_test_ref', to='tests.testmodel'
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='through_model',
+            field=models.ManyToManyField(
+                related_name='m2m_through_model_ref',
+                through='tests.CustomThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='through_model_en',
+            field=models.ManyToManyField(
+                null=True,
+                related_name='manytomanyfieldmodel_through_model_en_set',
+                through='tests.CustomThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='through_model_de',
+            field=models.ManyToManyField(
+                null=True,
+                related_name='manytomanyfieldmodel_through_model_de_set',
+                through='tests.CustomThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='trans_through_model',
+            field=models.ManyToManyField(
+                related_name='m2m_trans_through_model_ref',
+                through='tests.RegisteredThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='trans_through_model_en',
+            field=models.ManyToManyField(
+                null=True,
+                related_name='m2m_trans_through_model_ref',
+                through='tests.RegisteredThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='trans_through_model_de',
+            field=models.ManyToManyField(
+                null=True,
+                related_name='m2m_trans_through_model_ref',
+                through='tests.RegisteredThroughModel',
+                to='tests.testmodel',
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='untrans',
+            field=models.ManyToManyField(related_name='m2m_untrans_ref', to='tests.nontranslated'),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='untrans_en',
+            field=models.ManyToManyField(
+                null=True, related_name='m2m_untrans_ref', to='tests.nontranslated'
+            ),
+        ),
+        migrations.AddField(
+            model_name='manytomanyfieldmodel',
+            name='untrans_de',
+            field=models.ManyToManyField(
+                null=True, related_name='m2m_untrans_ref', to='tests.nontranslated'
+            ),
+        ),
+        migrations.CreateModel(
+            name='CustomThroughModel_de',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'rel_1',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='CustomThroughModel_de+',
+                        to='tests.manytomanyfieldmodel',
+                    ),
+                ),
+                (
+                    'rel_2',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='CustomThroughModel_de+',
+                        to='tests.testmodel',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'custom through model [de]',
+                'verbose_name_plural': 'custom through models [de]',
+                'db_table': 'tests_customthroughmodel_de',
+                'db_tablespace': '',
+                'auto_created': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='CustomThroughModel_en',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'rel_1',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='CustomThroughModel_en+',
+                        to='tests.manytomanyfieldmodel',
+                    ),
+                ),
+                (
+                    'rel_2',
+                    models.ForeignKey(
+                        db_tablespace='',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='CustomThroughModel_en+',
+                        to='tests.testmodel',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'custom through model [en]',
+                'verbose_name_plural': 'custom through models [en]',
+                'db_table': 'tests_customthroughmodel_en',
+                'db_tablespace': '',
+                'auto_created': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='customthroughmodel',
+            name='rel_1',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='tests.manytomanyfieldmodel'
+            ),
+        ),
+        migrations.AddField(
+            model_name='customthroughmodel',
+            name='rel_2',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='tests.testmodel'
+            ),
+        ),
+        migrations.CreateModel(
             name='ProxyTestModel',
             fields=[],
             options={

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -56,7 +56,7 @@ class FileFieldsModel(models.Model):
     image = models.ImageField(upload_to='modeltranslation_tests', null=True, blank=True)
 
 
-# ######### Foreign Key / OneToOneField testing
+# ######### Foreign Key / OneToOneField / ManytoManyField testing
 
 
 class NonTranslated(models.Model):
@@ -112,6 +112,43 @@ class OneToOneFieldModel(models.Model):
         related_name="test_o2o",
         on_delete=models.CASCADE,
     )
+
+
+class ManyToManyFieldModel(models.Model):
+    title = models.CharField(gettext_lazy('title'), max_length=255)
+    test = models.ManyToManyField(
+        TestModel,
+        related_name="m2m_test_ref",
+    )
+    self_call_1 = models.ManyToManyField("self")
+    # test multiple self m2m
+    self_call_2 = models.ManyToManyField("self")
+    through_model = models.ManyToManyField(TestModel, through="CustomThroughModel")
+    trans_through_model = models.ManyToManyField(
+        TestModel, related_name="m2m_trans_through_model_ref", through="RegisteredThroughModel"
+    )
+    untrans = models.ManyToManyField(
+        NonTranslated,
+        related_name="m2m_untrans_ref",
+    )
+
+
+class CustomThroughModel(models.Model):
+    rel_1 = models.ForeignKey(ManyToManyFieldModel, on_delete=models.CASCADE)
+    rel_2 = models.ForeignKey(TestModel, on_delete=models.CASCADE)
+
+    @property
+    def test_property(self):
+        return "%s_%s" % (self.__class__.__name__, self.rel_1_id)
+
+    def test_method(self):
+        return self.rel_1_id + 1
+
+
+class RegisteredThroughModel(models.Model):
+    rel_1 = models.ForeignKey(ManyToManyFieldModel, on_delete=models.CASCADE)
+    rel_2 = models.ForeignKey(TestModel, on_delete=models.CASCADE)
+    title = models.CharField(max_length=255)
 
 
 # ######### Custom fields testing

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -41,7 +41,7 @@ from modeltranslation.utils import (
 request = None
 
 # How many models are registered for tests.
-TEST_MODELS = 36
+TEST_MODELS = 40
 
 
 class reload_override_settings(override_settings):
@@ -992,6 +992,294 @@ class ForeignKeyFieldsTest(ModeltranslationTestBase):
     def test_indonesian(self):
         field = models.ForeignKeyModel._meta.get_field('test')
         assert field.attname != build_localized_fieldname(field.name, 'id')
+
+
+class ManyToManyFieldsTest(ModeltranslationTestBase):
+    @classmethod
+    def setUpClass(cls):
+        # 'model' attribute cannot be assigned to class in its definition,
+        # because ``models`` module will be reloaded and hence class would use old model classes.
+        super(ManyToManyFieldsTest, cls).setUpClass()
+        cls.model = models.ManyToManyFieldModel
+
+    def test_translated_models(self):
+        field_names = dir(self.model())
+        assert 'id' in field_names
+        for f in ('test', 'test_de', 'test_en', 'self_call_1', 'self_call_1_en', 'self_call_1_de'):
+            assert f in field_names
+
+    def test_db_column_names(self):
+        meta = self.model._meta
+
+        # Make sure the correct database columns always get used:
+        field = meta.get_field('test')
+        assert field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_test"
+
+        field = meta.get_field('test_en')
+        assert field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_test_en"
+
+        field = meta.get_field('test_de')
+        assert field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_test_de"
+
+        field = meta.get_field('self_call_1')
+        assert field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_self_call_1"
+
+        field = meta.get_field('self_call_1_en')
+        assert (
+            field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_self_call_1_en"
+        )
+
+        field = meta.get_field('self_call_1_de')
+        assert (
+            field.remote_field.through._meta.db_table == "tests_manytomanyfieldmodel_self_call_1_de"
+        )
+
+        field = meta.get_field('through_model')
+        assert field.remote_field.through._meta.db_table == "tests_customthroughmodel"
+
+        field = meta.get_field('through_model_en')
+        assert field.remote_field.through._meta.db_table == "tests_customthroughmodel_en"
+
+        field = meta.get_field('through_model_de')
+        assert field.remote_field.through._meta.db_table == "tests_customthroughmodel_de"
+
+    def test_translated_models_instance(self):
+        models.TestModel.objects.bulk_create(
+            (
+                models.TestModel(title_en='m2m_test_%s_en' % i, title_de='m2m_test_%s_de' % i)
+                for i in range(10)
+            )
+        )
+        self.model.objects.bulk_create(
+            (
+                self.model(title_en='m2m_test_%s_en' % i, title_de='m2m_test_%s_de' % i)
+                for i in range(10)
+            )
+        )
+        models.NonTranslated.objects.bulk_create(
+            (models.NonTranslated(title='m2m_test_%s' % i) for i in range(10))
+        )
+
+        testmodel_qs = models.TestModel.objects.all()
+        untranslated_qs = models.NonTranslated.objects.all()
+        self_qs = self.model.objects.all()
+
+        inst = self.model()
+        inst.save()
+
+        trans_real.activate("de")
+        inst.test.set(list(testmodel_qs.filter(pk__lt=2).values_list("pk", flat=True)))
+        assert inst.test.through.objects.all().count() == testmodel_qs.filter(pk__lt=2).count()
+
+        inst.through_model.set(testmodel_qs.filter(pk__lt=4))
+        assert (
+            inst.through_model.through.objects.all().count()
+            == testmodel_qs.filter(pk__lt=4).count()
+        )
+
+        inst.self_call_2.set(self_qs.filter(pk__gt=4))
+        assert inst.self_call_2.all().count() == self_qs.filter(pk__gt=4).count()
+
+        trans_real.activate("en")
+        inst.trans_through_model.through.objects.bulk_create(
+            (
+                inst.trans_through_model.through(
+                    title_en='m2m_test_%s_en' % i,
+                    title_de='m2m_test_%s_de' % i,
+                    rel_1_id=int(inst.pk),
+                    rel_2_id=i,
+                )
+                for i in range(1, 3)
+            )
+        )
+        assert inst.trans_through_model.all().count() == 2
+
+        inst.untrans.set(untranslated_qs)
+        assert inst.untrans.through.objects.all().count() == untranslated_qs.count()
+
+        inst.self_call_1.set(self_qs.filter(pk__lt=4))
+        assert (
+            inst.self_call_1.filter(
+                pk__in=self_qs.filter(pk__lt=4).values_list("pk", flat=True)
+            ).count()
+            == self_qs.filter(pk__lt=4).count()
+        )
+
+        trans_real.activate("de")
+        assert inst.test.through.objects.all().count() == testmodel_qs.filter(pk__lt=2).count()
+        assert (
+            inst.through_model.through.objects.all().count()
+            == testmodel_qs.filter(pk__lt=4).count()
+        )
+        assert inst.untrans.through.objects.count() == 0
+        assert inst.self_call_1.count() == 0
+
+        assert inst.trans_through_model == getattr(inst, "trans_through_model_de")
+
+        # Test prevent fallbacks:
+        trans_real.activate("en")
+        with default_fallback():
+            assert inst.untrans.through.objects.all().count() == untranslated_qs.count()
+            assert inst.trans_through_model == getattr(inst, "trans_through_model_en")
+
+        # Test through properties and methods inheriance:
+        trans_real.activate("de")
+        through_inst = inst.through_model.through.objects.first()
+        assert through_inst.test_property == "CustomThroughModel_de_%s" % inst.pk
+        assert through_inst.test_method() == inst.pk + 1
+
+        # Check filtering in direct way + lookup spanning
+        manager = self.model.objects
+        trans_real.activate("de")
+        assert manager.filter(test__in=testmodel_qs.filter(pk__lt=2)).count() == 1
+        assert manager.filter(test_en__in=testmodel_qs.filter(pk__lt=2)).count() == 0
+        assert manager.filter(test_de__in=testmodel_qs.filter(pk__lt=2)).count() == 1
+
+        assert (
+            manager.filter(
+                through_model__title__in=testmodel_qs.filter(pk__lt=4).values_list(
+                    "title", flat=True
+                )
+            )
+            .distinct()
+            .count()
+            == 1
+        )
+        assert (
+            manager.filter(
+                through_model_en__title__in=testmodel_qs.filter(pk__lt=4).values_list(
+                    "title", flat=True
+                )
+            ).count()
+            == 0
+        )
+        assert (
+            manager.filter(
+                through_model_de__title__in=testmodel_qs.filter(pk__lt=4).values_list(
+                    "title", flat=True
+                )
+            )
+            .distinct()
+            .count()
+            == 1
+        )
+
+        assert manager.filter(self_call_2__in=self_qs.filter(pk__gt=4)).distinct().count() == 7
+        assert manager.filter(self_call_2_en__in=self_qs.filter(pk__gt=4)).count() == 0
+        assert manager.filter(self_call_2_de__in=self_qs.filter(pk__gt=4)).distinct().count() == 7
+
+        trans_real.activate("en")
+        assert manager.filter(trans_through_model__in=testmodel_qs.filter(pk__lt=2)).count() == 1
+        assert manager.filter(trans_through_model_de__in=testmodel_qs.filter(pk__lt=2)).count() == 0
+        assert manager.filter(trans_through_model_en__in=testmodel_qs.filter(pk__lt=2)).count() == 1
+
+        assert manager.filter(untrans__in=untranslated_qs).distinct().count() == 1
+        assert manager.filter(untrans_de__in=untranslated_qs).count() == 0
+        assert manager.filter(untrans_en__in=untranslated_qs).distinct().count() == 1
+
+        assert manager.filter(self_call_1__in=self_qs.filter(pk__lt=4)).distinct().count() == 1
+        assert manager.filter(self_call_1_de__in=self_qs.filter(pk__lt=4)).count() == 0
+        assert manager.filter(self_call_1_en__in=self_qs.filter(pk__lt=4)).distinct().count() == 1
+
+    def test_reverse_relations(self):
+        models.TestModel.objects.bulk_create(
+            (
+                models.TestModel(title_en='m2m_test_%s_en' % i, title_de='m2m_test_%s_de' % i)
+                for i in range(10)
+            )
+        )
+        self.model.objects.bulk_create(
+            (
+                self.model(title_en='m2m_test_%s_en' % i, title_de='m2m_test_%s_de' % i)
+                for i in range(10)
+            )
+        )
+        models.NonTranslated.objects.bulk_create(
+            (models.NonTranslated(title='m2m_test_%s' % i) for i in range(10))
+        )
+        inst_both = self.model(title_en="inst_both_en", title_de="inst_both_de")
+        inst_both.save()
+        inst_en = self.model(title_en="inst_en_en", title_de="inst_en_de")
+        inst_en.save()
+        inst_de = self.model(title_en="inst_de_en", title_de="inst_de_de")
+        inst_de.save()
+        testmodel_qs = models.TestModel.objects.all()
+        inst_both.test_en.set(testmodel_qs)
+        inst_both.test_de.set(testmodel_qs)
+        inst_en.test_en.set(testmodel_qs)
+        inst_de.test_de.set(testmodel_qs)
+
+        # Check that the reverse accessors are created on the model:
+        # Explicit related_name
+        testmodel_fields = get_field_names(models.TestModel)
+        testmodel_methods = dir(models.TestModel)
+
+        assert 'm2m_test_ref' in testmodel_fields
+        assert 'm2m_test_ref_de' in testmodel_fields
+        assert 'm2m_test_ref_en' in testmodel_fields
+        assert 'm2m_test_ref' in testmodel_methods
+        assert 'm2m_test_ref_de' in testmodel_methods
+        assert 'm2m_test_ref_en' in testmodel_methods
+        # Implicit related_name: manager descriptor name != query field name
+        assert 'customthroughmodel' in testmodel_fields
+        assert 'customthroughmodel_en' in testmodel_fields
+        assert 'customthroughmodel_de' in testmodel_fields
+        assert 'manytomanyfieldmodel_set' in testmodel_methods
+        assert 'manytomanyfieldmodel_en_set' in testmodel_methods
+        assert 'manytomanyfieldmodel_de_set' in testmodel_methods
+
+        test_inst = models.TestModel.objects.first()
+        # Check the German reverse accessor:
+        assert inst_both in test_inst.m2m_test_ref_de.all()
+        assert inst_de in test_inst.m2m_test_ref_de.all()
+        assert inst_en not in test_inst.m2m_test_ref_de.all()
+
+        # Check the English reverse accessor:
+        assert inst_both in test_inst.m2m_test_ref_en.all()
+        assert inst_en in test_inst.m2m_test_ref_en.all()
+        assert inst_de not in test_inst.m2m_test_ref_en.all()
+
+        # Check the default reverse accessor:
+        trans_real.activate("de")
+        assert inst_de in test_inst.m2m_test_ref.all()
+        assert inst_en not in test_inst.m2m_test_ref.all()
+        trans_real.activate("en")
+        assert inst_en in test_inst.m2m_test_ref.all()
+        assert inst_de not in test_inst.m2m_test_ref.all()
+
+        # Check implicit related_name reverse accessor:
+        inst_en.through_model.set(testmodel_qs)
+        assert inst_en in test_inst.manytomanyfieldmodel_set.all()
+
+        # Check filtering in reverse way + lookup spanning:
+
+        manager = models.TestModel.objects
+        trans_real.activate("de")
+        assert manager.filter(m2m_test_ref__in=[inst_both]).count() == 10
+        assert manager.filter(m2m_test_ref__in=[inst_de]).count() == 10
+        assert manager.filter(m2m_test_ref__id__in=[inst_de.pk]).count() == 10
+        assert manager.filter(m2m_test_ref__in=[inst_en]).count() == 0
+        assert manager.filter(m2m_test_ref_en__in=[inst_en]).count() == 10
+        assert manager.filter(manytomanyfieldmodel__in=[inst_en]).count() == 0
+        assert manager.filter(manytomanyfieldmodel_en__in=[inst_en]).count() == 10
+        assert manager.filter(m2m_test_ref__title='inst_de_de').distinct().count() == 10
+        assert manager.filter(m2m_test_ref__title='inst_de_en').distinct().count() == 0
+        assert manager.filter(m2m_test_ref__title_en='inst_de_en').distinct().count() == 10
+        assert manager.filter(m2m_test_ref_en__title='inst_en_de').distinct().count() == 10
+
+        trans_real.activate("en")
+        assert manager.filter(m2m_test_ref__in=[inst_both]).count() == 10
+        assert manager.filter(m2m_test_ref__in=[inst_en]).count() == 10
+        assert manager.filter(m2m_test_ref__id__in=[inst_en.pk]).count() == 10
+        assert manager.filter(m2m_test_ref__in=[inst_de]).count() == 0
+        assert manager.filter(m2m_test_ref_de__in=[inst_de]).count() == 10
+        assert manager.filter(manytomanyfieldmodel__in=[inst_en]).count() == 10
+        assert manager.filter(manytomanyfieldmodel__in=[inst_de]).count() == 0
+        assert manager.filter(manytomanyfieldmodel_de__in=[inst_de]).count() == 0
+        assert manager.filter(m2m_test_ref__title='inst_en_en').distinct().count() == 10
+        assert manager.filter(m2m_test_ref__title='inst_en_de').distinct().count() == 0
+        assert manager.filter(m2m_test_ref__title_de='inst_en_de').distinct().count() == 10
+        assert manager.filter(m2m_test_ref_de__title='inst_de_en').distinct().count() == 10
 
 
 class OneToOneFieldsTest(ForeignKeyFieldsTest):

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -69,7 +69,7 @@ class FileFieldsModelTranslationOptions(TranslationOptions):
     )
 
 
-# ######### Foreign Key / OneToOneField testing
+# ######### Foreign Key / OneToOneField / ManytoManyField testing
 
 
 @register(models.ForeignKeyModel)
@@ -100,6 +100,24 @@ class FilteredTestModelTranslationOptions(TranslationOptions):
 
 @register(models.ForeignKeyFilteredModel)
 class ForeignKeyFilteredModelTranslationOptions(TranslationOptions):
+    fields = ('title',)
+
+
+@register(models.ManyToManyFieldModel)
+class ManyToManyFieldModelTranslationOptions(TranslationOptions):
+    fields = (
+        "title",
+        "test",
+        "self_call_1",
+        "self_call_2",
+        "through_model",
+        "trans_through_model",
+        "untrans",
+    )
+
+
+@register(models.RegisteredThroughModel)
+class RegisteredThroughModelTranslationOptions(TranslationOptions):
     fields = ('title',)
 
 

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from functools import partial
+from typing import Callable, Iterable
 
 import django
 from django.core.exceptions import ImproperlyConfigured
@@ -445,7 +446,7 @@ class Translator(object):
         # All seen models (model class -> ``TranslationOptions`` instance).
         self._registry = {}
         # List of funcs to execute after all imports are done.
-        self._lazy_operations = []
+        self._lazy_operations: Iterable[Callable] = []
 
     def register(self, model_or_iterable, opts_class=None, **options):
         """
@@ -652,11 +653,11 @@ class Translator(object):
             )
         return opts
 
-    def execute_lazy_operations(self):
+    def execute_lazy_operations(self) -> None:
         while self._lazy_operations:
             self._lazy_operations.pop(0)(translator=self)
 
-    def lazy_operation(self, func, *args, **kwargs):
+    def lazy_operation(self, func: Callable, *args, **kwargs) -> None:
         self._lazy_operations.append(partial(func, *args, **kwargs))
 
 

--- a/modeltranslation/translator.py
+++ b/modeltranslation/translator.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import django
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Manager, ForeignKey, OneToOneField, options
+from django.db.models import Manager, ForeignKey, ManyToManyField, OneToOneField, options
 from django.db.models.base import ModelBase
 from django.db.models.signals import post_init
 from django.utils.functional import cached_property
@@ -14,6 +14,7 @@ from modeltranslation.fields import (
     create_translation_field,
     TranslationFieldDescriptor,
     TranslatedRelationIdDescriptor,
+    TranslatedManyToManyDescriptor,
     LanguageCacheSingleObjectDescriptor,
 )
 from modeltranslation.manager import (
@@ -443,6 +444,8 @@ class Translator(object):
     def __init__(self):
         # All seen models (model class -> ``TranslationOptions`` instance).
         self._registry = {}
+        # List of funcs to execute after all imports are done.
+        self._lazy_operations = []
 
     def register(self, model_or_iterable, opts_class=None, **options):
         """
@@ -543,11 +546,16 @@ class Translator(object):
                 fallback_undefined=field_fallback_undefined,
             )
             setattr(model, field_name, descriptor)
-            if isinstance(field, ForeignKey):
+            if isinstance(field, (ForeignKey, ManyToManyField)):
                 # We need to use a special descriptor so that
                 # _id fields on translated ForeignKeys work
                 # as expected.
-                desc = TranslatedRelationIdDescriptor(field_name, model_fallback_languages)
+                desc_class = (
+                    TranslatedManyToManyDescriptor
+                    if isinstance(field, ManyToManyField)
+                    else TranslatedRelationIdDescriptor
+                )
+                desc = desc_class(field_name, model_fallback_languages)
                 setattr(model, field.get_attname(), desc)
 
                 # Set related field names on other model
@@ -643,6 +651,13 @@ class Translator(object):
                 'The model "%s" is not registered for ' 'translation' % model.__name__
             )
         return opts
+
+    def execute_lazy_operations(self):
+        while self._lazy_operations:
+            self._lazy_operations.pop(0)(translator=self)
+
+    def lazy_operation(self, func, *args, **kwargs):
+        self._lazy_operations.append(partial(func, *args, **kwargs))
 
 
 # This global object represents the singleton translator object

--- a/modeltranslation/utils.py
+++ b/modeltranslation/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 
+from django.db import models
 from django.utils.encoding import force_str
 from django.utils.translation import get_language as _get_language
 from django.utils.translation import get_language_info
@@ -184,10 +185,9 @@ def parse_field(setting, field_name, default):
         return setting
 
 
-def patch_intermediary_model(field, lang, translator):
-    from django.db import models
+def build_localized_intermediary_model(intermediary_model: models.Model, lang: str) -> models.Model:
+    from modeltranslation.translator import translator
 
-    intermediary_model = field.remote_field.through
     meta = type(
         "Meta",
         (),
@@ -218,7 +218,7 @@ def patch_intermediary_model(field, lang, translator):
 
     def lazy_register_model(old_model, new_model, translator):
         cls_opts = translator._get_options_for_model(old_model)
-        if cls_opts.registered and not new_model in translator._registry:
+        if cls_opts.registered and new_model not in translator._registry:
             name = "%sTranslationOptions" % new_model.__name__
             translator.register(new_model, type(name, (cls_opts.__class__,), {}))
 


### PR DESCRIPTION
I've added support to translate M2M fields.
I know that supporting relational fields can be a little controversial.
This patch is a step forward in the path that has brought the support to FK and OneToOne fields. 

This patch supports:
 - simple field with explicit or implicit related_name
 - multiple symmetrical field (aka "self") on same model
 - explicit "through model" with custom methods and properties
 - explicit "through model" with translated fields (registered with translator)
 - auto-popolate management command
 
This patch does not support:
 - fallbacks (this is not a technical problem but a conceptual one, do we really need fallbacks on m2m ? What is the definition of empty relation ? Since the field descriptor returns a manager, this could lead to involuntary setting relations on wrong manager. I'm open to suggestions)

I hope you appreciate the work I've done and I'm confident it will be merged soon.
Feel free to ask any question about the implementation, I'm open to review the code with you.

Bye, :)