### PR TITLE
Add support for JSONField and fixed the update_translation_fields command

### DIFF
--- a/modeltranslation/fields.py
+++ b/modeltranslation/fields.py
@@ -21,6 +21,7 @@ SUPPORTED_FIELDS = (
     # Above implies also CommaSeparatedIntegerField, EmailField, FilePathField, SlugField
     # and URLField as they are subclasses of CharField.
     fields.TextField,
+    fields.json.JSONField,
     fields.IntegerField,
     # Above implies also BigIntegerField, SmallIntegerField, PositiveIntegerField and
     # PositiveSmallIntegerField, as they are subclasses of IntegerField.

--- a/modeltranslation/management/commands/update_translation_fields.py
+++ b/modeltranslation/management/commands/update_translation_fields.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                 def_lang_fieldname = build_localized_fieldname(field_name, lang)
 
                 # We'll only update fields which do not have an existing value
-                q = Q(**{def_lang_fieldname: None})
+                q = Q(**{f"{def_lang_fieldname}__isnull": True})
                 field = model._meta.get_field(field_name)
                 if isinstance(field, ManyToManyField):
                     trans_field = getattr(model, def_lang_fieldname)

--- a/modeltranslation/tests/migrations/0001_initial.py
+++ b/modeltranslation/tests/migrations/0001_initial.py
@@ -465,6 +465,9 @@ class Migration(migrations.Migration):
                 ('genericip', models.GenericIPAddressField(blank=True, null=True)),
                 ('genericip_de', models.GenericIPAddressField(blank=True, null=True)),
                 ('genericip_en', models.GenericIPAddressField(blank=True, null=True)),
+                ('json', models.JSONField(blank=True, null=True)),
+                ('json_de', models.JSONField(blank=True, null=True)),
+                ('json_en', models.JSONField(blank=True, null=True)),
             ],
         ),
         migrations.CreateModel(

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -169,6 +169,7 @@ class OtherFieldsModel(models.Model):
     datetime = models.DateTimeField(blank=True, null=True)
     time = models.TimeField(blank=True, null=True)
     genericip = models.GenericIPAddressField(blank=True, null=True)
+    json = models.JSONField(blank=True, null=True)
 
 
 class FancyDescriptor:

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -136,6 +136,7 @@ class OtherFieldsModelTranslationOptions(TranslationOptions):
         'date',
         'datetime',
         'time',
+        'json',
     )
 
 


### PR DESCRIPTION
Add support for JSONField in modeltranslation/fields.py and update_translation_fields command, and add tests for JSONField support.

Even if you prefer to not add the JSONField to the list of supported fields #614, the changes to update_translation_fields.py help to fix #615 .