### PR TITLE
Added a pre_save signal to fix the update_fields parameter.

### DIFF
--- a/modeltranslation/signals.py
+++ b/modeltranslation/signals.py
@@ -1,0 +1,24 @@
+from modeltranslation.translator import rewrite_lookup_key
+
+
+def delete_mt_init(sender, instance, **kwargs):
+    """
+    Delete _mt_init attribute from instance.
+    """
+    if hasattr(instance, '_mt_init'):
+        del instance._mt_init
+
+
+def populate_update_fields(sender, instance, signal, raw, update_fields, **kwargs):
+    """
+    Populate update_fields with translated fields when save is called with
+    update_fields argument.
+    """
+    if update_fields is not None:
+        translated_update_fields = []
+        for field in update_fields:
+            translated_update_fields.append(field)
+            translated_update_fields.append(rewrite_lookup_key(instance.__class__, field))
+        translated_update_fields = frozenset(translated_update_fields)
+        if update_fields != translated_update_fields:
+            instance.save(update_fields=translated_update_fields, **kwargs)

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -489,6 +489,39 @@ class ModeltranslationTest(ModeltranslationTestBase):
         assert instance.title_en == 'old en'
         assert instance.title_de == 'old de'
 
+    def test_save_with_update_fields(self):
+        """
+        Test that save with update_fields works as expected
+        """
+        instance = models.TestModel.objects.create(title_de='old de', title_en='old en')
+
+        instance.title = 'NEW DE TITLE'
+        instance.save(update_fields=['title'])
+
+        instance.refresh_from_db()
+
+        assert instance.title == 'NEW DE TITLE'
+        assert instance.title_en == 'old en'
+        assert instance.title_de == 'NEW DE TITLE'
+
+        instance.title = 'NEW DE TITLE 2'
+
+        with self.assertNumQueries(1):
+            instance.save(update_fields=['title', 'title_de'])
+
+        instance.refresh_from_db()
+        assert instance.title == 'NEW DE TITLE 2'
+        assert instance.title_en == 'old en'
+        assert instance.title_de == 'NEW DE TITLE 2'
+
+        instance.title_en = 'NEW EN TITLE'
+        instance.save(update_fields=['title_en'])
+
+        instance.refresh_from_db()
+        assert instance.title == 'NEW DE TITLE 2'
+        assert instance.title_en == 'NEW EN TITLE'
+        assert instance.title_de == 'NEW DE TITLE 2'
+
 
 class ModeltranslationTransactionTest(ModeltranslationTransactionTestBase):
     def test_unique_nullable_field(self):


### PR DESCRIPTION
I have implemented a pre_save signal that checks whether the update_fields parameter exists. If it is present, the program verifies whether it contains the expected translated field names. If not, the system updates the update_fields parameter and reruns the save method.

#682 