### PR TITLE
Fix Literal import in python<3.8

### DIFF
--- a/modeltranslation/thread_context.py
+++ b/modeltranslation/thread_context.py
@@ -1,7 +1,12 @@
 import threading
-from typing import Literal, Union
+from typing import Union
 
 from modeltranslation import settings
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 AutoPopulate = Union[bool, Literal["all", "default", "required"]]
 


### PR DESCRIPTION
Fix **Literal** import error when the Python version is under 3.8

`ImportError: cannot import name 'Literal'`