### PR TITLE
Remove typing-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 django = ">=3.2"
-typing-extensions = "*"
 
 [tool.poetry.dev-dependencies]
 pdbpp = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ license = New BSD
 [options]
 install_requires =
     Django>=3.2
-    typing-extensions
     importlib-metadata; python_version<"3.8"
 packages =
     modeltranslation


### PR DESCRIPTION
Not used since 3c6cbd59a7e6ddf1ed64dd75fff0d1304c477f14.