### PR TITLE
Fixed bug in tabbed_translation_fields.js (issue #597)

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -541,9 +541,7 @@ var google, django, gettext;
         );
 
         $(document).ready(function () {
-          $(window).on("load", function () {
             handleTabularAddAnotherInline(tabularInlineGroup);
-          });
         });
       });
     }


### PR DESCRIPTION
Fixed an issue in file tabbed_translation_fields.js where the add new inline event would not fire. The problem occurred mainly in Firefox, but sometimes also occurred in Chrome


Isue #597 