### PR TITLE
showcase for issue with foreign keys defined in "app.ModelName" format in abstract base classes

### DIFF
--- a/modeltranslation/fields.py
+++ b/modeltranslation/fields.py
@@ -249,8 +249,9 @@ class TranslationField:
                 self.related_query_name = lambda: loc_related_query_name
             self.remote_field.related_name = build_localized_fieldname(current, self.language)
             self.remote_field.field = self
-            if hasattr(self.remote_field.model._meta, "_related_objects_cache"):
-                del self.remote_field.model._meta._related_objects_cache
+            if not type(self.remote_field.model) == str:
+                if hasattr(self.remote_field.model._meta, "_related_objects_cache"):
+                    del self.remote_field.model._meta._related_objects_cache
 
     # Django 1.5 changed definition of __hash__ for fields to be fine with hash requirements.
     # It spoiled our machinery, since TranslationField has the same creation_counter as its

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -79,14 +79,14 @@ class AbstractWithForeignKeyModel(models.Model):
 class ForeignKeyModel(AbstractWithForeignKeyModel, models.Model):
     title = models.CharField(gettext_lazy("title"), max_length=255)
     test = models.ForeignKey(
-        "tests.TestModel",
+        TestModel,
         null=True,
         related_name="test_fks",
         on_delete=models.CASCADE,
     )
     optional = models.ForeignKey("tests.TestModel", blank=True, null=True, on_delete=models.CASCADE)
     hidden = models.ForeignKey(
-        "tests.TestModel",
+        TestModel,
         blank=True,
         null=True,
         related_name="+",
@@ -100,7 +100,7 @@ class ForeignKeyModel(AbstractWithForeignKeyModel, models.Model):
         on_delete=models.CASCADE,
     )
     untrans = models.ForeignKey(
-        "tests.TestModel",
+        TestModel,
         blank=True,
         null=True,
         related_name="test_fks_un",

--- a/modeltranslation/tests/models.py
+++ b/modeltranslation/tests/models.py
@@ -64,17 +64,29 @@ class NonTranslated(models.Model):
     title = models.CharField(gettext_lazy("title"), max_length=255)
 
 
-class ForeignKeyModel(models.Model):
-    title = models.CharField(gettext_lazy("title"), max_length=255)
-    test = models.ForeignKey(
-        TestModel,
+class AbstractWithForeignKeyModel(models.Model):
+    test_in_abstract = models.ForeignKey(
+        "tests.TestModel",
         null=True,
         related_name="test_fks",
         on_delete=models.CASCADE,
     )
-    optional = models.ForeignKey(TestModel, blank=True, null=True, on_delete=models.CASCADE)
+
+    class Meta:
+        abstract = True
+
+
+class ForeignKeyModel(AbstractWithForeignKeyModel, models.Model):
+    title = models.CharField(gettext_lazy("title"), max_length=255)
+    test = models.ForeignKey(
+        "tests.TestModel",
+        null=True,
+        related_name="test_fks",
+        on_delete=models.CASCADE,
+    )
+    optional = models.ForeignKey("tests.TestModel", blank=True, null=True, on_delete=models.CASCADE)
     hidden = models.ForeignKey(
-        TestModel,
+        "tests.TestModel",
         blank=True,
         null=True,
         related_name="+",
@@ -88,7 +100,7 @@ class ForeignKeyModel(models.Model):
         on_delete=models.CASCADE,
     )
     untrans = models.ForeignKey(
-        TestModel,
+        "tests.TestModel",
         blank=True,
         null=True,
         related_name="test_fks_un",

--- a/modeltranslation/tests/translation.py
+++ b/modeltranslation/tests/translation.py
@@ -74,8 +74,18 @@ class FileFieldsModelTranslationOptions(TranslationOptions):
 # ######### Foreign Key / OneToOneField / ManytoManyField testing
 
 
+@register(models.AbstractWithForeignKeyModel)
+class AbstractWithForeignKeyModelTranslationOptions(TranslationOptions):
+    fields = (
+        "test_in_abstract",
+    )
+
+
 @register(models.ForeignKeyModel)
-class ForeignKeyModelTranslationOptions(TranslationOptions):
+class ForeignKeyModelTranslationOptions(
+    AbstractWithForeignKeyModelTranslationOptions,
+    TranslationOptions
+):
     fields = (
         "title",
         "test",


### PR DESCRIPTION
Somehow the field.model is not yet a class, but still a string, in this particular case. 

Tried a fix (modeltranslation/fields.py), but issue seems deeper, I guess it should really just not be a string?

This PR just shows the problem.