### PR TITLE
fix: Remove deprecated test config starting from Django 5.0

### DIFF
--- a/modeltranslation/tests/settings.py
+++ b/modeltranslation/tests/settings.py
@@ -10,9 +10,6 @@ def _get_database_config():
     conf = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:",
-        "TEST": {
-            "SERIALIZE": False,
-        },
     }
     if db == "mysql":
         conf.update(
@@ -60,3 +57,7 @@ MODELTRANSLATION_FALLBACK_LANGUAGES = ()
 ROOT_URLCONF = "modeltranslation.tests.urls"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+TEST_NON_SERIALIZED_APPS = (
+    "django.contrib.auth",
+)


### PR DESCRIPTION
Hello,

I found and resolved the issue with testing not functioning in Django 5.0 version, after seeing the [issue comment](https://github.com/deschler/django-modeltranslation/issues/719#issuecomment-2077809395).

The cause was the `"TEST": {"SERIALIZE": False}` option inside the `_get_database_config` in tests/settings.py. 
This option was deprecated since version [4.0](https://docs.djangoproject.com/en/5.0/releases/4.0/#id2) and removed in version [5.0](https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0).

Removing `"TEST": {"SERIALIZE": False}` leads to an error related to `GroupTranslationOptions` in tests/translation.py.

```shell
self = <django.db.backends.sqlite3.base.SQLiteCursorWrapper object at 0x7f9c9513b880>
query = 'SELECT "auth_group"."id", "auth_group"."name", "auth_group"."name_de", "auth_group"."name_en" FROM "auth_group" ORDER BY "auth_group"."id" ASC', params = ()

    def execute(self, query, params=None):
        if params is None:
            return super().execute(query)
        # Extract names if params is a mapping, i.e. "pyformat" style is used.
        param_names = list(params) if isinstance(params, Mapping) else None
        query = self.convert_query(query, param_names=param_names)
>       return super().execute(query, params)
E       django.db.utils.OperationalError: no such column: auth_group.name_de
```
To resolve this, I added the `TEST_NONSERIALIZED_APPS` option.
