### PR TITLE
Removed protocol from admin javascript links.

### DIFF
--- a/docs/modeltranslation/admin.rst
+++ b/docs/modeltranslation/admin.rst
@@ -237,7 +237,7 @@ The proposed way to include it is through the inner ``Media`` class of a
         class Media:
             js = (
                 'modeltranslation/js/force_jquery.js',
-                'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js',
+                '//ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js',
                 'modeltranslation/js/tabbed_translation_fields.js',
             )
             css = {
@@ -262,8 +262,8 @@ by including this in your ``Media`` class instead:
     class NewsAdmin(TranslationAdmin):
         class Media:
             js = (
-                'http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
-                'http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js',
+                '//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
+                '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js',
                 'modeltranslation/js/tabbed_translation_fields.js',
             )
             css = {


### PR DESCRIPTION
Just followed installation instructions, copy-pasted blindly these javascript files and then took me a few minutes to figure out, why tabs were not working on my production site. This will fix it in the documentation.