### PR TITLE
provide tests for wrong dict access of admin class not raising TypeError

### DIFF
--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2430,6 +2430,7 @@ class TranslationAdminTest(ModeltranslationTestBase):
         try:
             test = TestModelAdmin["my_attribute"]
             # don't know how to fail here?!
+            # as we should have a type error!
             assert True == False
         except TypeError:
             pass

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -2422,6 +2422,18 @@ class TranslationAdminTest(ModeltranslationTestBase):
         self.test_obj.delete()
         super().tearDown()
 
+    def test_admin_class_dict_access_raises_type_error(self):
+
+        class TestModelAdmin(admin.TranslationAdmin):
+            my_attribute = "default"
+
+        try:
+            test = TestModelAdmin["my_attribute"]
+            # don't know how to fail here?!
+            assert True == False
+        except TypeError:
+            pass
+
     def test_default_fields(self):
         class TestModelAdmin(admin.TranslationAdmin):
             pass


### PR DESCRIPTION
this is the cause for #745 and #748. I don't have a solution (yet).