### PR TITLE
feat: add changelog to project urls in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ project_urls =
     Source = https://github.com/deschler/django-modeltranslation
     Documentation = https://django-modeltranslation.readthedocs.org/en/latest
     Mailing List = http://groups.google.com/group/django-modeltranslation
+    Changelog = https://github.com/deschler/django-modeltranslation/blob/master/CHANGELOG.md
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Make it easier to find the change log on PyPI by listing it as one of the `Projekt-Links`.