### PR TITLE
fix: collect languages for `MainSwitch` from all modeltranslation fields

### DIFF
--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -469,17 +469,9 @@ var google, django, gettext;
     var MainSwitch = {
       languages: [],
       $select: $("<select id='modeltranslation-main-switch' class='modeltranslation-switch'>"),
-
-      init: function (groupedTranslations, tabs) {
+      init: function (languages, tabs) {
         var self = this;
-        $.each(groupedTranslations, function (id, languages) {
-          $.each(languages, function (lang) {
-            if ($.inArray(lang, self.languages) < 0) {
-              self.languages.push(lang);
-            }
-          });
-        });
-        $.each(this.languages, function (idx, language) {
+        $.each(languages, function (idx, language) {
           self.$select.append(
             $(
               '<option value="' +
@@ -511,6 +503,18 @@ var google, django, gettext;
       },
     };
 
+    var getLanguages = function(mtFields) {
+      let languages = [];
+      $.each(mtFields, function (_idx, el) {
+          const ids = $(el).attr("id").split("_");
+          const lang = ids[ids.length - 1];
+          if ($.inArray(lang, languages) < 0) {
+            languages.push(lang);
+          }
+        });
+      return languages;
+    }
+
     if ($("body").hasClass("change-form")) {
       // Group normal fields and fields in (existing) stacked inlines
       var grouper = new TranslationFieldGrouper({
@@ -519,8 +523,9 @@ var google, django, gettext;
           .filter(":parents(.tabular)")
           .filter(":parents(.empty-form)"),
       });
+      var languages = getLanguages($(".mt").filter("input, textarea, select, iframe, div"));
       MainSwitch.init(
-        grouper.groupedTranslations,
+        languages,
         createTabs(grouper.groupedTranslations)
       );
 

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -469,6 +469,7 @@ var google, django, gettext;
     var MainSwitch = {
       languages: [],
       $select: $("<select id='modeltranslation-main-switch' class='modeltranslation-switch'>"),
+
       init: function (languages, tabs) {
         var self = this;
         $.each(languages, function (idx, language) {

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -512,7 +512,7 @@ var google, django, gettext;
           .filter(":parents(.tabular)")
           .filter(":parents(.empty-form)"),
       });
-      var languages = getLanguages($(".mt").filter("input, textarea, select, iframe, div"));
+      var languages = getLanguages($(".mt").filter("input, textarea, select"));
       MainSwitch.init(
         languages,
         createTabs(grouper.groupedTranslations)

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -503,18 +503,6 @@ var google, django, gettext;
       },
     };
 
-    var getLanguages = function(mtFields) {
-      let languages = [];
-      $.each(mtFields, function (_idx, el) {
-          const ids = $(el).attr("id").split("_");
-          const lang = ids[ids.length - 1];
-          if ($.inArray(lang, languages) < 0) {
-            languages.push(lang);
-          }
-        });
-      return languages;
-    }
-
     if ($("body").hasClass("change-form")) {
       // Group normal fields and fields in (existing) stacked inlines
       var grouper = new TranslationFieldGrouper({
@@ -549,6 +537,19 @@ var google, django, gettext;
         });
       });
     }
+
+    function getLanguages (mtFields) {
+      let languages = [];
+      $.each(mtFields, function (_idx, el) {
+          const ids = $(el).attr("id").split("_");
+          const lang = ids[ids.length - 1];
+          if ($.inArray(lang, languages) < 0) {
+            languages.push(lang);
+          }
+        });
+      return languages;
+    }
+
   });
 })();
 


### PR DESCRIPTION
I'm using django-modeltranslations in my project. In there, I have two models, `ChoiceList` and `Choice`:
```python 
class ChoiceList(models.Model):
    key = models.SlugField(max_length=64, primary_key=True)

class Choice(models.Model):
    key = models.SlugField(max_length=128)
    text = models.CharField()
    choicelist = models.ForeignKey(
        ChoiceList,
        on_delete=models.CASCADE,
        related_name='choices',
    )
```
Only the child model (`Choice`) has registered translation fields:
```python
@register(Choice)
class ChoiceTranslationOptions(TranslationOptions):
    fields = ('text',)
```

The admin form with this setup works really nicely already:
```python
class ChoiceInline(TranslationTabularInline):
    model = Choice

class ChoiceListAdmin(TabbedTranslationAdmin):
    model = ChoiceList
    inlines = [ChoiceInline]
```
BUT: the language `MainSwitch` on top of the form was empty, due to the way the `TranslationFieldGrouper` in `tabbed_translation_fields.js` was used for collecting these languages.

<img width="237" height="50" alt="Screenshot 2026-03-09 at 15 44 34" src="https://github.com/user-attachments/assets/ec5d38f9-5e43-497b-a1ec-62101a5d2df8" />

This PR collects the languages to be displayed in the `MainSwitch` from all `.mt` classed elements and initializes the `TranslationFieldGrouper` with those languages.

Now the display is as it should be, and switching via the main switch works.
<img width="1174" height="555" alt="Screenshot 2026-03-10 at 11 45 34" src="https://github.com/user-attachments/assets/915311a5-8bc7-4b93-9fc3-a7692156aaa3" />
