### PR TITLE
Fix crash rewriting Transform expressions in update()/filter()

### DIFF
--- a/modeltranslation/manager.py
+++ b/modeltranslation/manager.py
@@ -312,11 +312,9 @@ class MultilingualQuerySet(QuerySet[_T]):
             return q
         if isinstance(q, Node):
             q.children = list(map(self._rewrite_f, q.children))  # type: ignore[arg-type]
-        # Django >= 1.8
-        if hasattr(q, "lhs"):
-            q.lhs = self._rewrite_f(q.lhs)
-        if hasattr(q, "rhs"):
-            q.rhs = self._rewrite_f(q.rhs)
+            return q
+        if hasattr(q, "get_source_expressions") and hasattr(q, "set_source_expressions"):
+            q.set_source_expressions(list(map(self._rewrite_f, q.get_source_expressions())))
         return q
 
     def _rewrite_filter_or_exclude(self, args: Any, kwargs: Any) -> tuple[Any, Any]:

--- a/modeltranslation/tests/tests.py
+++ b/modeltranslation/tests/tests.py
@@ -17,7 +17,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db import IntegrityError
 from django.db.models import CharField, Count, F, Q, Value
-from django.db.models.functions import Cast, Concat
+from django.db.models.functions import Cast, Concat, Length
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.translation import get_language, override, trans_real
@@ -2547,6 +2547,18 @@ class TestManager(ModeltranslationTestBase):
             n = models.ManagerTestModel.objects.all()[0]
             assert n.visits_en == 11
             assert n.visits_de == 22
+
+    def test_update_with_transform(self):
+        """
+        update() should not crash on Transform expressions (e.g. Length()),
+        whose .lhs is a read-only property. Regression test for #819.
+        """
+        models.ManagerTestModel.objects.create(title_en="abc", title_de="de")
+
+        assert "en" == get_language()
+        models.ManagerTestModel.objects.update(visits=Length("title"))
+        n = models.ManagerTestModel.objects.all()[0]
+        assert n.visits_en == 3
 
     def test_order_by(self):
         """Check that field names are rewritten in order_by keys."""


### PR DESCRIPTION
_rewrite_f assigned to .lhs/.rhs directly, which fails for Transform
subclasses (e.g. Length()) since .lhs is a read-only property there.
Use get_source_expressions()/set_source_expressions() instead, which
works uniformly across Lookup, Transform, and other expression types.

Add a test.

Resolves: https://github.com/deschler/django-modeltranslation/issues/819
