### PR TITLE
Support dark mode and fix language selector in tabbed translation fields

### DIFF
--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -30,8 +30,8 @@ backward compatibility:
 .ui-tabs .ui-tabs-nav { margin: 0; padding: .2em .2em 0; }
 .ui-tabs .ui-tabs-nav li { list-style: none; float: left; position: relative; top: 1px; margin: 0 .2em 1px 0; border-bottom: 0 !important; padding: 0; white-space: nowrap; }
 .ui-tabs .ui-tabs-nav li a { float: left; padding: .5em 1em; text-decoration: none; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-active, .ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 1px; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
+.ui-tabs .ui-tabs-nav li.ui-tabs-active, .ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 0; }
+.ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
 .ui-tabs .ui-tabs-nav li a, .ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a { cursor: pointer; } /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
 .ui-tabs .ui-tabs-panel { display: block; border-width: 0; padding: 1em 1.4em; background: none; }
 .ui-tabs .ui-tabs-hide {
@@ -41,14 +41,21 @@ backward compatibility:
 
 /* custom tabs theme */
 .ui-tabs { padding: 0; }
-.ui-tabs .ui-tabs-nav { padding: 5px 0 0 10px; border-bottom: 1px solid #EEEEEE; }
+.ui-tabs .ui-tabs-nav {
+    padding: 5px 0 0 10px;
+    border-bottom: 1px solid var(--hairline-color, #EEEEEE);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    row-gap: 2px;
+}
 .ui-tabs .ui-tabs-nav li { margin: 0; }
 .ui-tabs .ui-tabs-nav li.required { font-weight: bold; }
 .ui-tabs .ui-tabs-nav li a {
-    border: 1px solid #CCCCCC;
-    background: #eeeeee repeat-x;
+    border: 1px solid var(--border-color, #CCCCCC);
+    background: var(--darkened-bg, #eeeeee);
     border-bottom-width: 0;
-    color: #666666;
+    color: var(--body-quiet-color, #666666);
     padding: 4px 10px 4px 10px;
     margin-top: 2px;
     -moz-border-radius-topright: 4px;
@@ -58,11 +65,14 @@ backward compatibility:
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
     font-size: 12px;
+    text-transform: uppercase;
+    font-weight: 500;
+    text-decoration: none !important;
 }
 
 .ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
-    background: #7CA0C7 repeat-x;
-    color: #fff;
+    background: var(--selected-row, #7CA0C7);
+    color: var(--link-fg, #fff);
     padding: 6px 10px 4px 10px;
     margin-top: 0;
 }
@@ -71,9 +81,13 @@ backward compatibility:
     padding: 0;
 }
 
+.modeltranslation-switch {
+    text-transform: uppercase;
+}
+
 .ui-tabs .ui-tab-has-errors a::after {
     content: "•";
-    color: #ba2121;
+    color: var(--error-fg, #ba2121);
     position: absolute;
     font-size: 1.8rem;
 }

--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -49,7 +49,7 @@ backward compatibility:
     align-items: flex-end;
     row-gap: 2px;
 }
-.ui-tabs .ui-tabs-nav li { margin: 0; }
+.ui-tabs .ui-tabs-nav li { margin: 0; float: none; position: static; top: 0; }
 .ui-tabs .ui-tabs-nav li.required { font-weight: bold; }
 .ui-tabs .ui-tabs-nav li a {
     border: 1px solid var(--border-color, #CCCCCC);

--- a/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
+++ b/modeltranslation/static/modeltranslation/css/tabbed_translation_fields.css
@@ -28,7 +28,7 @@ backward compatibility:
 .ui-widget-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
 .ui-tabs { position: relative; padding: .2em; zoom: 1; } /* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
 .ui-tabs .ui-tabs-nav { margin: 0; padding: .2em .2em 0; }
-.ui-tabs .ui-tabs-nav li { list-style: none; float: left; position: relative; top: 1px; margin: 0 .2em 1px 0; border-bottom: 0 !important; padding: 0; white-space: nowrap; }
+.ui-tabs .ui-tabs-nav li { list-style: none; margin: 0 .2em 1px 0; border-bottom: 0 !important; padding: 0; white-space: nowrap; }
 .ui-tabs .ui-tabs-nav li a { float: left; padding: .5em 1em; text-decoration: none; }
 .ui-tabs .ui-tabs-nav li.ui-tabs-active, .ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 0; }
 .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
@@ -49,7 +49,7 @@ backward compatibility:
     align-items: flex-end;
     row-gap: 2px;
 }
-.ui-tabs .ui-tabs-nav li { margin: 0; float: none; position: static; top: 0; }
+.ui-tabs .ui-tabs-nav li { margin: 0; }
 .ui-tabs .ui-tabs-nav li.required { font-weight: bold; }
 .ui-tabs .ui-tabs-nav li a {
     border: 1px solid var(--border-color, #CCCCCC);

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -562,7 +562,7 @@ var google, django, gettext;
     function getLanguages (mtFields) {
       let languages = [];
       $.each(mtFields, function (_idx, el) {
-        $.each($(el).attr("class").split(" "), function (_idx, cls) {
+        $.each(($(el).attr("class") || "").split(" "), function (_idx, cls) {
           if (cls.substring(0, TranslationField.cssPrefix.length) === TranslationField.cssPrefix) {
             var tfield = new TranslationField({ el: el, cls: cls });
             if ($.inArray(tfield.lang, languages) < 0) {

--- a/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
+++ b/modeltranslation/static/modeltranslation/js/tabbed_translation_fields.js
@@ -39,6 +39,17 @@ var google, django, gettext;
 
     const selectors = selectorMapping[detectTemplate()];
 
+    function getLanguageDisplayName(lang) {
+      var langTag = lang.replace("_", "-");
+      var displayLocale = document.documentElement.lang || langTag;
+      try {
+        var name = new Intl.DisplayNames([displayLocale], { type: "language" }).of(langTag);
+        return name.charAt(0).toUpperCase() + name.slice(1);
+      } catch (e) {
+        return langTag;
+      }
+    }
+
     var TranslationField = function (options) {
       this.el = options.el;
       this.cls = options.cls;
@@ -242,7 +253,9 @@ var google, django, gettext;
           tab = $(
             `<li class='${selectors["tabLiClass"]} ` +
               (label.hasClass("required") ? "required" : "") + "'" +
-              `><a class="${selectors["tabAClass"]}" href="#` +
+              `><a class="${selectors["tabAClass"]}" title="` +
+              getLanguageDisplayName(lang) +
+              `" href="#` +
               tabId +
               '">' +
               lang.replace("_", "-") +
@@ -444,7 +457,9 @@ var google, django, gettext;
           $tab = $(
             "<li" +
               ($(el).hasClass("mt-default") ? ' class="required"' : "") +
-              '><a href="#' +
+              '><a title="' +
+              getLanguageDisplayName(lang) +
+              '" href="#' +
               tabId +
               '">' +
               lang.replace("_", "-") +
@@ -492,6 +507,11 @@ var google, django, gettext;
         this.$select.change(function () {
           $.each(tabs, function (idx, tab) {
             tab.tabs("option", "active", parseInt(self.$select.val(), 10));
+          });
+        });
+        $.each(tabs, function (idx, tab) {
+          tab.on("tabsactivate", function (event, ui) {
+            self.$select.val(ui.newTab.index());
           });
         });
       },
@@ -542,12 +562,15 @@ var google, django, gettext;
     function getLanguages (mtFields) {
       let languages = [];
       $.each(mtFields, function (_idx, el) {
-          const ids = $(el).attr("id").split("_");
-          const lang = ids[ids.length - 1];
-          if ($.inArray(lang, languages) < 0) {
-            languages.push(lang);
+        $.each($(el).attr("class").split(" "), function (_idx, cls) {
+          if (cls.substring(0, TranslationField.cssPrefix.length) === TranslationField.cssPrefix) {
+            var tfield = new TranslationField({ el: el, cls: cls });
+            if ($.inArray(tfield.lang, languages) < 0) {
+              languages.push(tfield.lang);
+            }
           }
         });
+      });
       return languages;
     }
 


### PR DESCRIPTION
### CSS (`tabbed_translation_fields.css`)

* **Dark mode support**: Now uses Django's admin CSS variables, each with a fallback to the original hardcoded value, so installations without these variables retain exactly the same appearance as before.
* **Layout with many languages**: The tab bar now wraps onto multiple rows as needed.
* **Consistent tab style**: Added `text-transform: uppercase` and `font-weight: 500` to the tab labels to follow the same visual conventions as the Django admin.

### JS (`tabbed_translation_fields.js`)

* **One-way select sync**: Changing the select moved the active tab, but clicking a tab never updated the select. `MainSwitch.update()` now also listens for jQuery UI's `tabsactivate` event to keep both in sync.
* **Tab tooltips**: Each tab now has a `title` attribute containing the language's full display name (e.g. hovering over "fr" shows "French").
* **`getLanguages()` bug with compound language codes**: It extracted the language code by splitting the field's `id` attribute and taking the last segment. This breaks for language codes that contain an underscore (e.g. `zh_cn` or `zh_tw`), causing the select to contain `"cn"`/`"tw"` instead of `"zh-cn"`/`"zh-tw"`.

<img width="481" height="93" alt="Screenshot 2026-09-03 at 15 02 44" src="https://github.com/user-attachments/assets/235b62cc-8dc7-4f34-b67f-55c5b20b6576" />
<img width="481" height="93" alt="Screenshot 2026-09-03 at 15 02 52" src="https://github.com/user-attachments/assets/406438ef-5bfe-4a91-ad10-a9ea4edda111" />
